### PR TITLE
fix parallel builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -823,6 +823,8 @@ install(
   TARGETS MistController
   DESTINATION bin
 )
+# Needed to make parallel builds work well
+add_dependencies(MistOutHTTP MistController)
 
 ########################################
 # Make Clean                           #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,29 +338,7 @@ endif()
 ########################################
 # MistLib - Local Header Install       #
 ########################################
-if (${CMAKE_VERSION} VERSION_LESS 3.3.0)
-add_custom_command(OUTPUT ${BINARY_DIR}/mist/.headers
-  COMMAND ${CMAKE_COMMAND}
-  ARGS    -E make_directory ${BINARY_DIR}/mist
-  COMMAND cp
-  ARGS    ${libHeaders} ${BINARY_DIR}/mist
-  COMMAND touch
-  ARGS    ${BINARY_DIR}/mist/.headers
-  WORKING_DIRECTORY ${SOURCE_DIR}
-  DEPENDS ${libHeaders}
-)
-else()
-add_custom_command(OUTPUT ${BINARY_DIR}/mist/.headers
-  COMMAND ${CMAKE_COMMAND}
-  ARGS    -E make_directory ${BINARY_DIR}/mist
-  COMMAND ${CMAKE_COMMAND}
-  ARGS    -E copy ${libHeaders} ${BINARY_DIR}/mist
-  COMMAND ${CMAKE_COMMAND}
-  ARGS    -E touch ${BINARY_DIR}/mist/.headers
-  WORKING_DIRECTORY ${SOURCE_DIR}
-  DEPENDS ${libHeaders}
-)
-endif()
+file(COPY ${libHeaders} DESTINATION ${BINARY_DIR}/mist)
 
 ########################################
 # MistServer - Analysers               #
@@ -370,7 +348,6 @@ macro(makeAnalyser analyserName format)
     src/analysers/mist_analyse.cpp
     src/analysers/analyser.cpp
     src/analysers/analyser_${format}.cpp
-    ${BINARY_DIR}/mist/.headers
   )
   set_target_properties(MistAnalyser${analyserName} 
     PROPERTIES COMPILE_DEFINITIONS "ANALYSERHEADER=\"analyser_${format}.h\"; ANALYSERTYPE=Analyser${analyserName}"
@@ -404,7 +381,6 @@ makeAnalyser(RTSP rtsp) #LTS
 macro(makeUtil utilName utilFile)
   add_executable(MistUtil${utilName}
     src/utils/util_${utilFile}.cpp
-    ${BINARY_DIR}/mist/.headers
   )
   target_link_libraries(MistUtil${utilName}
     mist
@@ -429,7 +405,6 @@ endif()
 
 add_executable(MistTranslateH264
   src/analysers/h264_translate.cpp
-  ${BINARY_DIR}/mist/.headers
 )
 target_link_libraries(MistTranslateH264
   mist
@@ -444,7 +419,6 @@ macro(makeInput inputName format)
     src/input/input.cpp 
     src/input/input_${format}.cpp 
     src/io.cpp
-    ${BINARY_DIR}/mist/.headers
   )
   if (";${ARGN};" MATCHES ";with_srt;")
     target_link_libraries(MistIn${inputName} mist_srt )
@@ -521,7 +495,6 @@ macro(makeOutput outputName format)
     ${httpOutput}
     ${tsOutput} 
     ${mp4Output}
-    ${BINARY_DIR}/mist/.headers
   )
   set_target_properties(MistOut${outputName} 
     PROPERTIES COMPILE_DEFINITIONS "OUTPUTTYPE=\"output_${format}.h\";TS_BASECLASS=${tsBaseClass}"
@@ -564,7 +537,6 @@ makeOutput(RTSP rtsp)#LTS
 makeOutput(WAV wav)#LTS
 
 add_executable(MistProcFFMPEG
-  ${BINARY_DIR}/mist/.headers
   src/process/process_ffmpeg.cpp
   src/output/output_ebml.cpp
   src/input/input_ebml.cpp
@@ -576,7 +548,6 @@ add_executable(MistProcFFMPEG
 target_link_libraries(MistProcFFMPEG mist)
 
 add_executable(MistProcMKVExec
-  ${BINARY_DIR}/mist/.headers
   src/process/process_exec.cpp
   src/output/output_ebml.cpp
   src/input/input_ebml.cpp
@@ -588,7 +559,6 @@ add_executable(MistProcMKVExec
 target_link_libraries(MistProcMKVExec mist)
 
 add_executable(MistProcLivepeer
-  ${BINARY_DIR}/mist/.headers
   src/process/process_livepeer.cpp
   src/input/input.cpp
   src/output/output_http.cpp
@@ -609,7 +579,6 @@ if (WITH_SANITY)
 endif()
 
 add_executable(MistOutHTTP 
-  ${BINARY_DIR}/mist/.headers
   src/output/mist_out.cpp
   src/output/output.cpp
   src/output/output_http.cpp 
@@ -694,7 +663,6 @@ endif()
 ########################################
   add_executable(RelAccXSampler
     src/relaccxsampler.cpp
-    ${BINARY_DIR}/mist/.headers
   )
   target_link_libraries(RelAccXSampler
     mist 
@@ -844,7 +812,6 @@ add_executable(MistController
   src/controller/controller_api.cpp
   src/controller/controller_push.cpp
   generated/server.html.h
-  ${BINARY_DIR}/mist/.headers
 )
 set_target_properties(MistController
   PROPERTIES COMPILE_DEFINITIONS RELEASE=${RELEASE}
@@ -875,28 +842,27 @@ add_custom_target(clean-all
 ########################################
 # Tests                                #
 ########################################
-add_executable(urltest test/url.cpp ${BINARY_DIR}/mist/.headers)
+add_executable(urltest test/url.cpp)
 target_link_libraries(urltest mist)
 add_test(URLTest COMMAND urltest)
-add_executable(logtest test/log.cpp ${BINARY_DIR}/mist/.headers)
+add_executable(logtest test/log.cpp)
 target_link_libraries(logtest mist)
 add_test(LOGTest COMMAND logtest)
-add_executable(downloadertest test/downloader.cpp ${BINARY_DIR}/mist/.headers)
+add_executable(downloadertest test/downloader.cpp)
 target_link_libraries(downloadertest mist)
 add_test(DownloaderTest COMMAND downloadertest)
-add_executable(urireadertest test/urireader.cpp ${BINARY_DIR}/mist/.headers)
+add_executable(urireadertest test/urireader.cpp)
 target_link_libraries(urireadertest mist)
 add_test(URIReaderTest COMMAND urireadertest)
-add_executable(jsontest test/json.cpp ${BINARY_DIR}/mist/.headers)
+add_executable(jsontest test/json.cpp)
 target_link_libraries(jsontest mist)
 add_test(JSONTest COMMAND jsontest)
-add_executable(resolvetest test/resolve.cpp ${BINARY_DIR}/mist/.headers)
+add_executable(resolvetest test/resolve.cpp)
 target_link_libraries(resolvetest mist)
-add_executable(bitwritertest test/bitwriter.cpp ${BINARY_DIR}/mist/.headers)
+add_executable(bitwritertest test/bitwriter.cpp)
 target_link_libraries(bitwritertest mist)
 add_test(BitWriterTest COMMAND bitwritertest)
-add_executable(streamstatustest test/status.cpp ${BINARY_DIR}/mist/.headers)
+add_executable(streamstatustest test/status.cpp)
 target_link_libraries(streamstatustest mist)
-add_executable(websockettest test/websocket.cpp ${BINARY_DIR}/mist/.headers)
+add_executable(websockettest test/websocket.cpp)
 target_link_libraries(websockettest mist)
-


### PR DESCRIPTION
The first change adds an unconditionally copy of the Mist headers to the necessary directory, simplifying a lot of `.headers` logic.

The second change adds `MistController` as a dependency of `MistOutHTTP` so that `player.js.h` and other dependencies get generated at the right time. I tried using `MistAnalyserFLV` instead, per conversation, but that didn't work.