### PR TITLE
Enable parameters on tssrt input stream

### DIFF
--- a/lib/socket_srt.cpp
+++ b/lib/socket_srt.cpp
@@ -462,12 +462,11 @@ namespace Socket{
 
   SRTServer::SRTServer(int fromSock){conn = SRTConnection(fromSock);}
 
-  SRTServer::SRTServer(int port, std::string hostname, bool nonblock, const std::string &_direction){
+  SRTServer::SRTServer(int port, std::string hostname, std::map<std::string, std::string> _params, bool nonblock, const std::string &_direction){
     // We always create a server as listening
-    std::map<std::string, std::string> listenMode;
-    listenMode["mode"] = "listener";
+    _params["mode"] = "listener";
     if (hostname == ""){hostname = "0.0.0.0";}
-    conn.connect(hostname, port, _direction, listenMode);
+    conn.connect(hostname, port, _direction, _params);
     conn.setBlocking(true);
     if (!conn){
       ERROR_MSG("Unable to create socket");

--- a/lib/socket_srt.h
+++ b/lib/socket_srt.h
@@ -97,7 +97,7 @@ namespace Socket{
   public:
     SRTServer();
     SRTServer(int existingSock);
-    SRTServer(int port, std::string hostname, bool nonblock = false, const std::string &_direction = "input");
+    SRTServer(int port, std::string hostname, std::map<std::string, std::string> params, bool nonblock = false, const std::string &_direction = "input");
     SRTConnection accept(bool nonblock = false, const std::string &direction = "input");
     void setBlocking(bool blocking);
     bool connected() const;

--- a/src/input/input_tssrt.cpp
+++ b/src/input/input_tssrt.cpp
@@ -137,7 +137,9 @@ namespace Mist{
       HTTP::URL u(source);
       INFO_MSG("Parsed url: %s", u.getUrl().c_str());
       if (Socket::interpretSRTMode(u) == "listener"){
-        sSock = Socket::SRTServer(u.getPort(), u.host, false);
+        std::map<std::string, std::string> arguments;
+        HTTP::parseVars(u.args, arguments);
+        sSock = Socket::SRTServer(u.getPort(), u.host, arguments, false);
         struct sigaction new_action;
         struct sigaction cur_action;
         new_action.sa_sigaction = signal_handler;

--- a/src/output/output_tssrt.cpp
+++ b/src/output/output_tssrt.cpp
@@ -434,7 +434,8 @@ int main(int argc, char *argv[]){
       sigaction(SIGUSR1, &new_action, NULL);
     }
     if (conf.getInteger("port") && conf.getString("interface").size()){
-      server_socket = Socket::SRTServer(conf.getInteger("port"), conf.getString("interface"), false, "output");
+      std::map<std::string, std::string> arguments;
+      server_socket = Socket::SRTServer(conf.getInteger("port"), conf.getString("interface"), arguments, false, "output");
     }
     if (!server_socket.connected()){
       DEVEL_MSG("Failure to open socket");


### PR DESCRIPTION
Hi!

I notice no URL parameters are passed from the srt URL into the libsrt connection on the Input side (they are working properly on the output side).
This means encryption isn't working.

With the below change to pass the parameter through I was able to build and run Mist and get encryption working on SRT streams.