### PR TITLE
Add s3 protocol to `URIReader`

### DIFF
--- a/lib/timing.cpp
+++ b/lib/timing.cpp
@@ -114,3 +114,15 @@ std::string Util::getUTCString(uint64_t epoch){
            ptm->tm_mday, ptm->tm_hour, ptm->tm_min, ptm->tm_sec);
   return std::string(result);
 }
+
+std::string Util::getDateString(uint64_t epoch){
+  char buffer[80];
+  time_t rawtime = epoch;
+  if (!epoch) {
+    time(&rawtime);
+  }
+  struct tm * timeinfo;
+  timeinfo = localtime(&rawtime);
+  strftime(buffer, sizeof(buffer), "%a, %d %b %Y %H:%M:%S %z", timeinfo);
+  return std::string(buffer);
+}

--- a/lib/timing.h
+++ b/lib/timing.h
@@ -17,4 +17,5 @@ namespace Util{
   uint64_t getNTP();
   uint64_t epoch(); ///< Gets the amount of seconds since 01/01/1970.
   std::string getUTCString(uint64_t epoch = 0);
+  std::string getDateString(uint64_t epoch = 0);
 }// namespace Util

--- a/lib/urireader.cpp
+++ b/lib/urireader.cpp
@@ -197,6 +197,8 @@ namespace HTTP{
       }
       // Transform s3 url to HTTP request:
       httpHeaderOverride = s3TransformToHttp(myURI);
+      bool errorInSignatureCalculation = !httpHeaderOverride.continueOperation;
+      if(errorInSignatureCalculation) return false;
       // Do not return, continue to HTTP case
     }
 #endif // ifndef NOSSL

--- a/src/input/input_hls.cpp
+++ b/src/input/input_hls.cpp
@@ -170,8 +170,6 @@ namespace Mist{
     nextUTC = 0;
     id = 0; // to be set later
     INFO_MSG("Adding variant playlist: %s", uriSrc.c_str());
-    plsDL.dataTimeout = 15;
-    plsDL.retryCount = 8;
     lastFileIndex = 0;
     waitTime = 2;
     playlistEnd = false;
@@ -370,13 +368,17 @@ namespace Mist{
     std::ifstream fileSource;
 
     if (isUrl()){
-      if (!plsDL.get(uri) || !plsDL.isOk()){
-        FAIL_MSG("Could not download playlist '%s', aborting: %" PRIu32 " %s", uri.c_str(),
-                 plsDL.getStatusCode(), plsDL.getStatusText().c_str());
+      HTTP::URIReader plsDL;
+      plsDL.open(uri);
+      char * dataPtr;
+      size_t dataLen;
+      plsDL.readAll(dataPtr, dataLen);
+      if (!dataLen){
+        FAIL_MSG("Could not download playlist '%s', aborting.", uri.c_str());
         reloadNext = Util::bootSecs() + waitTime;
         return false;
       }
-      urlSource.str(plsDL.data());
+      urlSource.str().assign(dataPtr, dataLen);
     }else{
       fileSource.open(uri.c_str());
       if (!fileSource.good()){
@@ -1293,14 +1295,16 @@ namespace Mist{
     bool isUrl = (playlistLocation.find("://") != std::string::npos);
     if (isUrl){
       INFO_MSG("Downloading main playlist file from '%s'", uri.c_str());
-      HTTP::Downloader plsDL;
-      plsDL.dataTimeout = 15;
-      plsDL.retryCount = 8;
-      if (!plsDL.get(playlistRootPath) || !plsDL.isOk()){
+      HTTP::URIReader plsDL;
+      plsDL.open(playlistRootPath);
+      char * dataPtr;
+      size_t dataLen;
+      plsDL.readAll(dataPtr, dataLen);
+      if (!dataLen){
         FAIL_MSG("Could not download main playlist, aborting.");
         return false;
       }
-      urlSource.str(plsDL.data());
+      urlSource.str().assign(dataPtr, dataLen);
     }else{
       // If we're not a URL and there is no / at the start, ensure we get the full absolute path.
       if (playlistLocation[0] != '/'){

--- a/src/input/input_hls.cpp
+++ b/src/input/input_hls.cpp
@@ -587,6 +587,12 @@ namespace Mist{
     capa["source_match"].append("https://*.m3u");
     capa["source_match"].append("https-hls://*");
     capa["source_match"].append("http-hls://*");
+    capa["source_match"].append("s3+http://*.m3u8");
+    capa["source_match"].append("s3+http://*.m3u");
+    capa["source_match"].append("s3+https://*.m3u8");
+    capa["source_match"].append("s3+https://*.m3u");
+    capa["source_match"].append("s3+https-hls://*");
+    capa["source_match"].append("s3+http-hls://*");
 
     // All URLs can be set to always-on mode.
     capa["always_match"] = capa["source_match"];
@@ -1278,6 +1284,8 @@ namespace Mist{
     // Convert custom http(s)-hls protocols into regular notation.
     if (playlistRootPath.protocol == "http-hls"){playlistRootPath.protocol = "http";}
     if (playlistRootPath.protocol == "https-hls"){playlistRootPath.protocol = "https";}
+    if (playlistRootPath.protocol == "s3+http-hls"){playlistRootPath.protocol = "s3+http";}
+    if (playlistRootPath.protocol == "s3+https-hls"){playlistRootPath.protocol = "s3+https";}
 
     std::istringstream urlSource;
     std::ifstream fileSource;

--- a/src/input/input_hls.cpp
+++ b/src/input/input_hls.cpp
@@ -378,7 +378,7 @@ namespace Mist{
         reloadNext = Util::bootSecs() + waitTime;
         return false;
       }
-      urlSource.str().assign(dataPtr, dataLen);
+      urlSource.str(std::string(dataPtr, dataLen));
     }else{
       fileSource.open(uri.c_str());
       if (!fileSource.good()){
@@ -1296,7 +1296,10 @@ namespace Mist{
     if (isUrl){
       INFO_MSG("Downloading main playlist file from '%s'", uri.c_str());
       HTTP::URIReader plsDL;
-      plsDL.open(playlistRootPath);
+      if (!plsDL.open(playlistRootPath) || !plsDL){
+        FAIL_MSG("Could not open main playlist, aborting");
+        return false;
+      }
       char * dataPtr;
       size_t dataLen;
       plsDL.readAll(dataPtr, dataLen);
@@ -1304,7 +1307,7 @@ namespace Mist{
         FAIL_MSG("Could not download main playlist, aborting.");
         return false;
       }
-      urlSource.str().assign(dataPtr, dataLen);
+      urlSource.str(std::string(dataPtr, dataLen));
     }else{
       // If we're not a URL and there is no / at the start, ensure we get the full absolute path.
       if (playlistLocation[0] != '/'){

--- a/src/input/input_hls.h
+++ b/src/input/input_hls.h
@@ -68,8 +68,6 @@ namespace Mist{
     std::string uri; // link to the current playlistfile
     HTTP::URL root;
 
-    HTTP::Downloader plsDL;
-
     uint64_t reloadNext;
 
     uint32_t id;


### PR DESCRIPTION
Add S3 resource download to `URIReader` class.

The S3 URLs look like: 

`s3+https://s3_key:secret@storage.googleapis.com/alexk-dms-upload-test/testvideo.ts`
`s3+https://s3_key:secret@s3.amazonaws.com/alexk-dms-upload-test/testvideo.ts`

Where `s3_key` and `secret` fallback to environment variables `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` respectively.

We employ `AWS` authorization method that should support google, amazon and other S3 compatible cloud providers.

This PR adds logic to calculate `AWS` signature for S3 GET request. New logic is placed just before `HTTP/HTTPS` protocols to create proper HTTP request for `HTTP/HTTPS` logic. This means existing code path is reused and range requests are supported (`supportRangeRequest == true`).

# How to test

- Compile
- Run `./build/urireadertest "s3+https://your-key:your-secret@storage.googleapis.com/alexk-dms-upload-est/somedata.txt"`
- Observe file contents is produced on `stdout`


