### PR TITLE
Upstream MBED-TLS integrated SRTP support, allow building against it

### DIFF
--- a/lib/certificate.h
+++ b/lib/certificate.h
@@ -9,8 +9,12 @@
   communication. This certificate uses a 2048 bits RSA key.
 
  */
-
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_MAJOR > 2
+#include <mbedtls/build_info.h>
+#else
 #include <mbedtls/config.h>
+#endif
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/error.h>
@@ -32,4 +36,6 @@ public:
 public:
   mbedtls_x509_crt cert;
   mbedtls_pk_context key;       /* key context, stores private and public key. */
+private:
+  mbedtls_ctr_drbg_context rand_ctx;
 };

--- a/lib/dtls_srtp_handshake.h
+++ b/lib/dtls_srtp_handshake.h
@@ -1,8 +1,14 @@
 #pragma once
 
 #include <deque>
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_MAJOR == 2
 #include <mbedtls/certs.h>
 #include <mbedtls/config.h>
+#else
+#include <mbedtls/build_info.h>
+//#include <mbedtls/pk.h>
+#endif
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/debug.h>
 #include <mbedtls/entropy.h>
@@ -44,7 +50,16 @@ private:
   unsigned char master_secret[48];
   unsigned char randbytes[64];
   mbedtls_tls_prf_types tls_prf_type;
-  static int dtlsExtractKeyData( void *p_expkey,
+#if MBEDTLS_VERSION_MAJOR > 2
+  static void dtlsExtractKeyData( void *user,
+                              mbedtls_ssl_key_export_type type,
+                              const unsigned char *ms,
+                              size_t,
+                              const unsigned char client_random[32],
+                              const unsigned char server_random[32],
+                              mbedtls_tls_prf_types tls_prf_type );
+#else
+  static int dtlsExtractKeyData( void *user,
                               const unsigned char *ms,
                               const unsigned char *,
                               size_t,
@@ -54,7 +69,7 @@ private:
                               const unsigned char server_random[32],
                               mbedtls_tls_prf_types tls_prf_type );
 #endif
-
+#endif
 public:
   int (*write_callback)(const uint8_t *data, int *nbytes);
   std::deque<uint8_t> buffer; /* Accessed from BIO callbback. We copy the bytes you pass into `parse()` into this

--- a/lib/dtls_srtp_handshake.h
+++ b/lib/dtls_srtp_handshake.h
@@ -40,6 +40,20 @@ private:
   mbedtls_ssl_config ssl_conf;
   mbedtls_ssl_cookie_ctx cookie_ctx;
   mbedtls_timing_delay_context timer_ctx;
+#if HAVE_UPSTREAM_MBEDTLS_SRTP
+  unsigned char master_secret[48];
+  unsigned char randbytes[64];
+  mbedtls_tls_prf_types tls_prf_type;
+  static int dtlsExtractKeyData( void *p_expkey,
+                              const unsigned char *ms,
+                              const unsigned char *,
+                              size_t,
+                              size_t,
+                              size_t,
+                              const unsigned char client_random[32],
+                              const unsigned char server_random[32],
+                              mbedtls_tls_prf_types tls_prf_type );
+#endif
 
 public:
   int (*write_callback)(const uint8_t *data, int *nbytes);

--- a/lib/socket.h
+++ b/lib/socket.h
@@ -22,7 +22,11 @@
 #include "mbedtls/debug.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/error.h"
-#include "mbedtls/net.h"
+#if !HAVE_UPSTREAM_MBEDTLS_SRTP
+#include <mbedtls/net.h>
+#else
+#include "mbedtls/net_sockets.h"
+#endif
 #include "mbedtls/ssl.h"
 #endif
 

--- a/meson.build
+++ b/meson.build
@@ -18,18 +18,18 @@ if git.found()
   rv = run_command(git, 'describe', '--tags', check: false)
   version = rv.stdout().strip()
   if rv.returncode() != 0
-    fs = import('fs') 
+    fs = import('fs')
     if fs.is_file('VERSION')
       version = fs.read('VERSION').strip()
-    else 
+    else
       version = 'Unknown'
     endif
   endif
 else
-  fs = import('fs') 
+  fs = import('fs')
   if fs.is_file('VERSION')
     version = fs.read('VERSION').strip()
-  else 
+  else
     version = 'Unknown'
   endif
 endif
@@ -107,6 +107,21 @@ if usessl
   mbedcrypto = ccpp.find_library('mbedcrypto', required: false)
 
   # Test if we can compile the way we expect
+  ssl_deps = [mbedtls, mbedx509, mbedcrypto]
+
+  ##This currently only works for MbedTLS < 3
+  code_upstream = '''
+  #include <mbedtls/ssl.h>
+  static mbedtls_ssl_srtp_profile srtp_profiles[] ={MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_80,
+                                              MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32,
+                                              MBEDTLS_TLS_SRTP_UNSET};
+  static int test()
+  {
+    mbedtls_ssl_config ssl_conf;
+    mbedtls_ssl_conf_dtls_srtp_protection_profiles(&ssl_conf, srtp_profiles);
+    return 0;
+  }
+  '''
   code_ddvtech = '''
   #include <mbedtls/ssl.h>
   mbedtls_ssl_srtp_profile srtp_profiles[] ={MBEDTLS_SRTP_AES128_CM_HMAC_SHA1_80,
@@ -119,16 +134,19 @@ if usessl
     return 0;
   }
   '''
-  ddvtech_mbedtls = ccpp.compiles(code_ddvtech, dependencies: [mbedtls, mbedx509, mbedcrypto], name: 'MbedTLS is DDVTech fork')
-  if not mbedtls.found() or not ddvtech_mbedtls
+  have_upstream_mbedtls_srtp = ccpp.compiles(code_upstream, dependencies: ssl_deps, name: 'MbedTLS SRTP is upstream')
+  ddvtech_mbedtls = ccpp.compiles(code_ddvtech, dependencies: ssl_deps, name: 'MbedTLS SRTP is DDVTECH')
+
+  if not mbedtls.found() or (not ddvtech_mbedtls and not have_upstream_mbedtls_srtp)
     mbedtls_proj = subproject('mbedtls')
     mbedtls = mbedtls_proj.get_variable('mbedtls_dep')
     mbedx509 = mbedtls_proj.get_variable('mbedx509_dep')
     mbedcrypto = mbedtls_proj.get_variable('mbedcrypto_dep')
   endif
-
   mist_deps += [mbedtls, mbedx509, mbedcrypto]
   mist_deps += dependency('libsrtp2', default_options: ['tests=disabled'], fallback: ['libsrtp2', 'libsrtp2_dep'])
+
+  option_defines += int_opt.format('HAVE_UPSTREAM_MBEDTLS_SRTP', have_upstream_mbedtls_srtp.to_int())
 endif
 
 libsrt = false

--- a/src/output/output_https.cpp
+++ b/src/output/output_https.cpp
@@ -239,7 +239,11 @@ namespace Mist{
     }
 
     // Read key from cmdline option
+#if MBEDTLS_VERSION_MAJOR > 2
+    ret = mbedtls_pk_parse_keyfile(&pkey, config->getString("key").c_str(), NULL, mbedtls_ctr_drbg_random, &ctr_drbg);
+#else
     ret = mbedtls_pk_parse_keyfile(&pkey, config->getString("key").c_str(), 0);
+#endif
     if (ret != 0){
       FAIL_MSG("Could not load any keys from file: %s", config->getString("key").c_str());
       return;

--- a/src/output/output_https.h
+++ b/src/output/output_https.h
@@ -3,7 +3,11 @@
 #include <mbedtls/certs.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
+#if !HAVE_UPSTREAM_MBEDTLS_SRTP
 #include <mbedtls/net.h>
+#else
+#include <mbedtls/net_sockets.h>
+#endif
 #include <mbedtls/ssl.h>
 #include <mbedtls/timing.h>
 #include <mbedtls/x509.h>

--- a/src/output/output_https.h
+++ b/src/output/output_https.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "output.h"
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_MAJOR == 2
 #include <mbedtls/certs.h>
+#endif
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 #if !HAVE_UPSTREAM_MBEDTLS_SRTP
@@ -33,6 +36,7 @@ namespace Mist{
     static mbedtls_ssl_config sslConf;
     static mbedtls_x509_crt srvcert;
     static mbedtls_pk_context pkey;
+  
   };
 }// namespace Mist
 


### PR DESCRIPTION
This is a rework of #38 and based on #107

Dynamically detect MbedTLS SRTP support and compile against upstream version if found. 