### PR TITLE
input.cpp: TEMP UGLY HACK - disable all input stats

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -852,7 +852,7 @@ namespace Mist{
         userSelect[thisIdx].reload(streamName, thisIdx, COMM_STATUS_ACTIVE | COMM_STATUS_SOURCE | COMM_STATUS_DONOTTRACK);
       }
 
-      if (Util::bootSecs() - statTimer > 1){
+      if (false && Util::bootSecs() - statTimer > 1){
         // Connect to stats for INPUT detection
         if (!statComm){statComm.reload(streamName, getConnectedBinHost(), JSON::Value(getpid()).asString(), "INPUT:" + capa["name"].asStringRef(), "");}
         if (statComm){


### PR DESCRIPTION
this prevents the load balancer from pulling streams anywhere but from the actual source server and will hopefully work around some replication problems while we work on something better