### PR TITLE
HTTP timeout increase (5s -> 30s)

### DIFF
--- a/lib/downloader.cpp
+++ b/lib/downloader.cpp
@@ -8,7 +8,7 @@ namespace HTTP{
   Downloader::Downloader(){
     progressCallback = 0;
     connectedPort = 0;
-    dataTimeout = 5;
+    dataTimeout = 30;
     retryCount = 5;
     ssl = false;
     proxied = false;


### PR DESCRIPTION
This is to improve performance with slow HTTP URLs, particularly IPFS gateways