### PR TITLE
Ak/segmenting fixes

### DIFF
--- a/lib/dtsc.cpp
+++ b/lib/dtsc.cpp
@@ -1434,7 +1434,9 @@ namespace DTSC{
 
   /// Evaluates to true if this is a shared-memory-backed object, correctly mapped, with a non-exit
   /// state on the "stream" RelAccX page.
-  Meta::operator bool() const{return !isMemBuf && streamPage.mapped && !stream.isExit();}
+  Meta::operator bool() const{
+    return (!isMemBuf && streamPage.mapped && !stream.isExit()) || (isMemBuf && streamMemBuf && !stream.isExit());
+  }
 
   /// Intended to be used for encryption. Not currently called anywhere.
   size_t Meta::addCopy(size_t sourceTrack){

--- a/lib/dtsc.h
+++ b/lib/dtsc.h
@@ -476,6 +476,8 @@ namespace DTSC{
 
     void getHealthJSON(JSON::Value & returnReference) const;
 
+    bool isShared() const {return !isMemBuf;}
+
   protected:
     void sBufMem(size_t trackCount = DEFAULT_TRACK_COUNT);
     void sBufShm(const std::string &_streamName, size_t trackCount = DEFAULT_TRACK_COUNT, bool master = true);

--- a/lib/mp4_generic.cpp
+++ b/lib/mp4_generic.cpp
@@ -2734,7 +2734,7 @@ namespace MP4{
     }
     size_t count = 0;
     size_t offset = 78;
-    while (offset < payloadSize()){
+    while (offset <= payloadSize() - 8){
       offset += getBoxLen(offset);
       count++;
     }
@@ -2878,7 +2878,7 @@ namespace MP4{
     }
     size_t count = 0;
     size_t offset = 28;
-    while (offset < payloadSize()){
+    while (offset <= payloadSize() - 8){
       offset += getBoxLen(offset);
       count++;
     }

--- a/lib/url.cpp
+++ b/lib/url.cpp
@@ -211,11 +211,14 @@ std::string HTTP::URL::getFilePath() const{
 
 /// Returns whether the URL is probably pointing to a local file
 bool HTTP::URL::isLocalPath() const{
+  //Anything with a "file" protocol is explicitly a local file
+  if (protocol == "file"){return true;}
+
   // If we have no host, protocol or port we can assume it is a local path
-  if (host.size() || protocol.size() || port.size()){
-    return false;
-  }
-  return true;
+  if (!host.size() && !protocol.size() && !port.size()){return true;}
+
+  //Anything else is probably not local
+  return false;
 }
 
 /// Returns the URL in string format without auth and frag

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -645,7 +645,7 @@ namespace Mist{
     Comms::Connections statComm;
     uint64_t startTime = Util::bootSecs();
 
-    if (!M){
+    if (!M || !M.isShared()){
       // Initialize meta page
       meta.reInit(streamName, true);
     }else{


### PR DESCRIPTION
Fix for change that broke live streams [4ca53c1d0e073709cb234788226e7bcab0625504](https://github.com/DDVTECH/DMS/commit/4ca53c1d0e073709cb234788226e7bcab0625504)
Fix for mov segmenting crash [2d4508b049f35196c47625051351ea650a6c8cca](https://github.com/DDVTECH/DMS/commit/2d4508b049f35196c47625051351ea650a6c8cca)
Detection of local paths in URL library that we don't use yet [fb6d1bd4906a993b8a57a967ddeb8df2de227ccb](https://github.com/DDVTECH/DMS/commit/fb6d1bd4906a993b8a57a967ddeb8df2de227ccb)