### PR TITLE
input/input_mp4: allow option to output and read dtsh headers from a different location

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -85,6 +85,12 @@ namespace Mist{
     option["value"].append(0u);
     option["help"] = "Generate .dtsh, then exit";
     config->addOption("headeronly", option);
+    option.null();
+    option["arg"] = "string";
+    option["short"] = "F";
+    option["long"] = "dtshOutputFile";
+    option["help"] = "The output path for the generated .dtsh if -H (--headerOnly) is selected";
+    config->addOption("dtshoutput", option);
 
     /*LTS-START*/
     /*
@@ -1493,6 +1499,13 @@ namespace Mist{
   }
 
   bool Input::readExistingHeader(){
+    const char *origTarget = getenv("MST_ORIG_TARGET");
+    if (!origTarget) {
+	    INFO_MSG("env MST_ORIG_TARGET not set - running MistIn* out-of-band");
+	    return false;
+    }
+    std::string segmentOutputTarget(origTarget);
+    std::string inUrl = config->getString("input");
     if (config->getBool("realtime")){
       meta.reInit("", config->getString("input") + ".dtsh");
       if (!meta){return false;}
@@ -1514,9 +1527,14 @@ namespace Mist{
         return true;
       }
     }
-    // Try to read any existing DTSH file
-    std::string fileName = config->getString("input") + ".dtsh";
-    HIGH_MSG("Refreshing metadata for stream '%s'. Trying to reinit from file '%s'", streamName.c_str(), fileName.c_str());
+    // Try to read any existing DTSH file - the location of the DTSH file
+    // will typically be in the path specified in the MST_ORIG_TARGET env variable
+    std::string inputFile = config->getString("input") + ".dtsh";
+    std::string srcFileName = inputFile.substr(inputFile.find_last_of("/")+1);
+    std::string srcFilePath = segmentOutputTarget.substr(0, segmentOutputTarget.find_last_of("/")+1);
+    std::string fileName = srcFilePath + srcFileName;
+    INFO_MSG("Refreshing metadata for stream '%s'. Trying to reinit from file '%s'", streamName.c_str(), fileName.c_str());
+
     char *scanBuf;
     size_t fileSize;
     HTTP::URIReader inFile(fileName);

--- a/src/input/input_mp4.cpp
+++ b/src/input/input_mp4.cpp
@@ -196,7 +196,12 @@ namespace Mist{
       std::cerr << "Input from stdin not yet supported" << std::endl;
       return false;
     }
-    if (config->getBool("headeronly")){return true;}
+    std::string dtshOutUrl = config->getString("dtshoutput");
+    if (!config->getBool("headeronly") && !dtshOutUrl.empty() > 0){
+        return false;
+    } else if (config->getBool("headeronly")) {
+        return true;
+    }
     if (!config->getString("streamname").size()){
       if (config->getString("output") == "-"){
         std::cerr << "Output to stdout not yet supported" << std::endl;
@@ -515,13 +520,19 @@ namespace Mist{
     }
 
     std::string inUrl = config->getString("input");
+    std::string dtshOutUrl;
+    if (config->getBool("headeronly")) {
+      dtshOutUrl = config->getString("dtshoutput");
+    }
+    std::string outUrl = !dtshOutUrl.empty() ? dtshOutUrl : inUrl;
     // Export DTSH to file
     Socket::Connection outFile;
     int tmpFd = open("/dev/null", O_RDWR);
     outFile.open(tmpFd);
     Util::Procs::socketList.insert(tmpFd);
-    genericWriter(inUrl + ".dtsh", &outFile, false);
+    genericWriter(outUrl + ".dtsh", &outFile, false);
     if (outFile){M.send(outFile, false, M.getValidTracks(), false);}
+    Util::Procs::socketList.insert(tmpFd);
     bps = 0;
     std::set<size_t> tracks = M.getValidTracks();
     for (std::set<size_t>::iterator it = tracks.begin(); it != tracks.end(); it++){bps += M.getBps(*it);}


### PR DESCRIPTION
* Add option --dtshOutputFile to specify output file if --headerOnly option is used. This arg sets the output location of the dtsh headers.
* When an existing dtsh header is attempted to be read via readExistingHeader(), the url in --dtshOutputFile is used to read the header if it exists. If --headerOnly is not being used, then use the typical location to look for the headers.
* If MistInMP4 is launched by shelling out, then the MST_ORIG_TARGET env var is not set - this var is set by MistOut* process (e.g. MistOutHTTPTS) and contains the output location of the output segments. This URL is used as the location of the source of any existing dtsh headers when MistIn* processes are started.