### PR TITLE
shell expansion and parameters with spaces in ts-exec:, mkv-exec, JPEG, etc.

### DIFF
--- a/lib/procs.cpp
+++ b/lib/procs.cpp
@@ -268,6 +268,22 @@ std::string Util::Procs::getOutputOf(std::deque<std::string> &argDeq){
   return ret;
 }
 
+pid_t Util::Procs::StartPipedShell(const char *cmd, int *fdin, int *fdout, int *fderr){
+  const char *argv[] = {
+#if defined(__CYGWIN__) || defined(_WIN32)
+    "cmd",
+    "/C",
+#else
+    "/usr/bin/sh",
+    "-c",
+#endif
+    cmd,
+    NULL
+  };
+  pid_t ret = Util::Procs::StartPiped(argv, fdin, fdout, fderr);
+  return ret;
+}
+
 pid_t Util::Procs::StartPiped(std::deque<std::string> &argDeq, int *fdin, int *fdout, int *fderr){
   pid_t ret;
   char *const *argv = dequeToArgv(argDeq); // Note: Do not edit deque before executing command

--- a/lib/procs.h
+++ b/lib/procs.h
@@ -33,6 +33,7 @@ namespace Util{
     static std::string getOutputOf(std::deque<std::string> &argDeq);
     static pid_t StartPiped(const char *const *argv, int *fdin, int *fdout, int *fderr);
     static pid_t StartPiped(std::deque<std::string> &argDeq, int *fdin, int *fdout, int *fderr);
+    static pid_t StartPipedShell(const char *cmd, int *fdin, int *fdout, int *fderr);
     static void Stop(pid_t name);
     static void Murder(pid_t name);
     static void StopAll();

--- a/src/input/input_ebml.cpp
+++ b/src/input/input_ebml.cpp
@@ -102,28 +102,8 @@ namespace Mist{
     if (config->getString("input").substr(0, 9) == "mkv-exec:"){
       standAlone = false;
       std::string input = config->getString("input").substr(9);
-      char *args[128];
-      uint8_t argCnt = 0;
-      char *startCh = 0;
-      for (char *i = (char *)input.c_str(); i <= input.data() + input.size(); ++i){
-        if (!*i){
-          if (startCh){args[argCnt++] = startCh;}
-          break;
-        }
-        if (*i == ' '){
-          if (startCh){
-            args[argCnt++] = startCh;
-            startCh = 0;
-            *i = 0;
-          }
-        }else{
-          if (!startCh){startCh = i;}
-        }
-      }
-      args[argCnt] = 0;
-
       int fin = -1, fout = -1;
-      Util::Procs::StartPiped(args, &fin, &fout, 0);
+      Util::Procs::StartPipedShell(input.c_str(), &fin, &fout, 0);
       if (fout == -1){return false;}
       dup2(fout, 0);
       inFile = stdin;

--- a/src/input/input_h264.cpp
+++ b/src/input/input_h264.cpp
@@ -21,29 +21,8 @@ namespace Mist{
     if (config->getString("input") != "-"){
       std::string input = config->getString("input");
       input = input.substr(10);
-
-      char *args[128];
-      uint8_t argCnt = 0;
-      char *startCh = 0;
-      for (char *i = (char *)input.c_str(); i <= input.data() + input.size(); ++i){
-        if (!*i){
-          if (startCh){args[argCnt++] = startCh;}
-          break;
-        }
-        if (*i == ' '){
-          if (startCh){
-            args[argCnt++] = startCh;
-            startCh = 0;
-            *i = 0;
-          }
-        }else{
-          if (!startCh){startCh = i;}
-        }
-      }
-      args[argCnt] = 0;
-
       int fin = -1, fout = -1;
-      inputProcess = Util::Procs::StartPiped(args, &fin, &fout, 0);
+      inputProcess = Util::Procs::StartPipedShell(input.c_str(), &fin, &fout, 0);
       myConn.open(-1, fout);
     }else{
       myConn.open(fileno(stdout), fileno(stdin));

--- a/src/input/input_ts.cpp
+++ b/src/input/input_ts.cpp
@@ -306,28 +306,8 @@ namespace Mist{
     if (config->getString("input").substr(0, 8) == "ts-exec:"){
       standAlone = false;
       std::string input = config->getString("input").substr(8);
-      char *args[128];
-      uint8_t argCnt = 0;
-      char *startCh = 0;
-      for (char *i = (char *)input.c_str(); i <= input.data() + input.size(); ++i){
-        if (!*i){
-          if (startCh){args[argCnt++] = startCh;}
-          break;
-        }
-        if (*i == ' '){
-          if (startCh){
-            args[argCnt++] = startCh;
-            startCh = 0;
-            *i = 0;
-          }
-        }else{
-          if (!startCh){startCh = i;}
-        }
-      }
-      args[argCnt] = 0;
-
       int fin = -1, fout = -1;
-      inputProcess = Util::Procs::StartPiped(args, &fin, &fout, 0);
+      inputProcess = Util::Procs::StartPipedShell(input.c_str(), &fin, &fout, 0);
       tcpCon.open(-1, fout);
       return true;
     }

--- a/src/output/output_ebml.cpp
+++ b/src/output/output_ebml.cpp
@@ -17,28 +17,8 @@ namespace Mist{
     if (config->getString("target").size()){
       if (config->getString("target").substr(0, 9) == "mkv-exec:"){
         std::string input = config->getString("target").substr(9);
-        char *args[128];
-        uint8_t argCnt = 0;
-        char *startCh = 0;
-        for (char *i = (char *)input.c_str(); i <= input.data() + input.size(); ++i){
-          if (!*i){
-            if (startCh){args[argCnt++] = startCh;}
-            break;
-          }
-          if (*i == ' '){
-            if (startCh){
-              args[argCnt++] = startCh;
-              startCh = 0;
-              *i = 0;
-            }
-          }else{
-            if (!startCh){startCh = i;}
-          }
-        }
-        args[argCnt] = 0;
-
         int fin = -1;
-        Util::Procs::StartPiped(args, &fin, 0, 0);
+        Util::Procs::StartPipedShell(input.c_str(), &fin, 0, 0);
         myConn.open(fin, -1);
 
         wantRequest = false;

--- a/src/output/output_httpts.cpp
+++ b/src/output/output_httpts.cpp
@@ -29,28 +29,8 @@ namespace Mist{
       INFO_MSG("Rewriting SRT target '%s' to '%s'", tgt.c_str(), config->getString("target").c_str());
     } else if (config->getString("target").substr(0, 8) == "ts-exec:"){
       std::string input = config->getString("target").substr(8);
-      char *args[128];
-      uint8_t argCnt = 0;
-      char *startCh = 0;
-      for (char *i = (char *)input.c_str(); i <= input.data() + input.size(); ++i){
-        if (!*i){
-          if (startCh){args[argCnt++] = startCh;}
-          break;
-        }
-        if (*i == ' '){
-          if (startCh){
-            args[argCnt++] = startCh;
-            startCh = 0;
-            *i = 0;
-          }
-        }else{
-          if (!startCh){startCh = i;}
-        }
-      }
-      args[argCnt] = 0;
-
       int fin = -1;
-      Util::Procs::StartPiped(args, &fin, 0, 0);
+      Util::Procs::StartPipedShell(input.c_str(), &fin, 0, 0);
       myConn.open(fin, -1);
 
       wantRequest = false;

--- a/src/output/output_jpg.cpp
+++ b/src/output/output_jpg.cpp
@@ -237,28 +237,8 @@ namespace Mist{
              (Util::printDebugLevel >= DLVL_MEDIUM ? "" : "-v quiet"),
              config->getString("ffopts").c_str());
 
-    HIGH_MSG("Starting JPG command: %s", ffcmd);
-    char *args[128];
-    uint8_t argCnt = 0;
-    char *startCh = 0;
-    for (char *i = ffcmd; i - ffcmd < 256; ++i){
-      if (!*i){
-        if (startCh){args[argCnt++] = startCh;}
-        break;
-      }
-      if (*i == ' '){
-        if (startCh){
-          args[argCnt++] = startCh;
-          startCh = 0;
-          *i = 0;
-        }
-      }else{
-        if (!startCh){startCh = i;}
-      }
-    }
-    args[argCnt] = 0;
-
-    ffmpeg = Util::Procs::StartPiped(args, &fin, &fout, &ferr);
+    HIGH_MSG("Starting JPG command: %s", ffcmd);    
+    ffmpeg = Util::Procs::StartPipedShell(ffcmd, &fin, &fout, &ferr);
     if (ffmpeg < 2){
       Socket::Connection failure(fin, fout);
       failure.close();

--- a/src/process/process_exec.cpp
+++ b/src/process/process_exec.cpp
@@ -188,27 +188,7 @@ namespace Mist{
     char exec_cmd[10240];
     strncpy(exec_cmd, tmpCmd.c_str(), 10240);
     INFO_MSG("Executing command: %s", exec_cmd);
-    uint8_t argCnt = 0;
-    char *startCh = 0;
-    char *args[1280];
-    for (char *i = exec_cmd; i - exec_cmd < 10240; ++i){
-      if (!*i){
-        if (startCh){args[argCnt++] = startCh;}
-        break;
-      }
-      if (*i == ' '){
-        if (startCh){
-          args[argCnt++] = startCh;
-          startCh = 0;
-          *i = 0;
-        }
-      }else{
-        if (!startCh){startCh = i;}
-      }
-    }
-    args[argCnt] = 0;
-
-    execd_proc = Util::Procs::StartPiped(args, &pipein[0], &pipeout[1], &ffer);
+    execd_proc = Util::Procs::StartPipedShell(exec_cmd, &pipein[0], &pipeout[1], &ffer);
 
     uint64_t lastProcUpdate = Util::bootSecs();
     {

--- a/src/process/process_ffmpeg.cpp
+++ b/src/process/process_ffmpeg.cpp
@@ -834,30 +834,6 @@ namespace Mist{
     return false;
   }
 
-  /// prepare ffmpeg command by splitting the arguments before running
-  void OutENC::prepareCommand(){
-    // ffmpeg command
-    MEDIUM_MSG("ffmpeg command: %s", ffcmd);
-    uint8_t argCnt = 0;
-    char *startCh = 0;
-    for (char *i = ffcmd; i - ffcmd < 10240; ++i){
-      if (!*i){
-        if (startCh){args[argCnt++] = startCh;}
-        break;
-      }
-      if (*i == ' '){
-        if (startCh){
-          args[argCnt++] = startCh;
-          startCh = 0;
-          *i = 0;
-        }
-      }else{
-        if (!startCh){startCh = i;}
-      }
-    }
-    args[argCnt] = 0;
-  }
-
   void OutENC::setResolution(uint32_t x, uint32_t y){
     res_x = x;
     res_y = y;
@@ -884,8 +860,8 @@ namespace Mist{
       }
     }
 
-    prepareCommand();
-    ffout = p.StartPiped(args, &pipein[0], &pipeout[1], &ffer);
+    MEDIUM_MSG("ffmpeg command: %s", ffcmd);
+    ffout = p.StartPipedShell(ffcmd, &pipein[0], &pipeout[1], &ffer);
 
     while (conf.is_active && p.isRunning(ffout)){Util::sleep(200);}
 

--- a/src/process/process_ffmpeg.h
+++ b/src/process/process_ffmpeg.h
@@ -35,7 +35,6 @@ namespace Mist{
     bool checkAudioConfig();
     bool buildVideoCommand();
     bool buildAudioCommand();
-    void prepareCommand();
     std::set<std::string> supportedVideoCodecs;
     std::set<std::string> supportedAudioCodecs;
   };


### PR DESCRIPTION
In many instances, a shell command entered by user to supply a ts-exec: / mkv-exec: source or destination is not being treated as a shell expression but rather split by spaces.

This represents a problem when you need ffmpeg to play a file containing a space in ints file name or overlay a string of text with spaces. For example, the line:

```
ts-exec: ffmpeg -i "My File With Spaces.mpg" -c:v copy -mpegts -
```
will be split like this before invoking ffmpeg
```
ffmpeg|-i|"My|File|With|Spaces.mpg"|-c:v|copy|-mpegts -`
```
Other shell escaping characters like `, \ , ' also do not work.

The proposed PR solves this by actually invoking shell to interpret the entire command supplied by the user. (Inspired by https://github.com/php/php-src/blob/master/ext/standard/proc_open.c#L1211).

Note: WIN32 is implemented via CMD /C but untested.


