### PR TITLE
refactor: capitalize Input classes

### DIFF
--- a/src/input/input_aac.cpp
+++ b/src/input/input_aac.cpp
@@ -59,7 +59,7 @@
 #include "input_aac.h"     
 
 namespace Mist{
-  inputAAC::inputAAC(Util::Config *cfg) : Input(cfg){
+  InputAAC::InputAAC(Util::Config *cfg) : Input(cfg){
     capa["name"] = "AAC";
     capa["desc"] = "Allows loading AAC files";
     capa["source_match"] = "/*.aac";
@@ -75,9 +75,9 @@ namespace Mist{
     audioTrack = INVALID_TRACK_ID;
   }
 
-  inputAAC::~inputAAC(){}
+  InputAAC::~InputAAC(){}
 
-  bool inputAAC::checkArguments(){
+  bool InputAAC::checkArguments(){
     if (!config->getString("streamname").size()){
       if (config->getString("output") == "-"){
         Util::logExitReason(ER_FORMAT_SPECIFIC, "Output to stdout not yet supported");
@@ -92,7 +92,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputAAC::preRun(){
+  bool InputAAC::preRun(){
     inFile.open(config->getString("input"));
     if (!inFile || inFile.isEOF()){
       Util::logExitReason(ER_READ_START_FAILURE, "Reading header for '%s' failed: Could not open input stream", config->getString("input").c_str());
@@ -111,7 +111,7 @@ namespace Mist{
   // Overrides the default keepRunning function to shut down
   // if the file disappears or changes, by polling the file's mtime.
   // If neither applies, calls the original function.
-  bool inputAAC::keepRunning(){
+  bool InputAAC::keepRunning(){
     struct stat statData;
     if (stat(config->getString("input").c_str(), &statData) == -1){
       INFO_MSG("Shutting down because input file disappeared");
@@ -127,7 +127,7 @@ namespace Mist{
 
   // Reads the first frame to init track
   // Then calls getNext untill all other frames have been added to the DTSH file
-  bool inputAAC::readHeader(){
+  bool InputAAC::readHeader(){
     char *aacData;
     char *aacFrame;
     uint64_t frameSize = 0;
@@ -209,7 +209,7 @@ namespace Mist{
   
   // Reads the ADTS frame at the current position then updates thisPacket
   // @param <idx> contains the trackID to which we want to add the ADTS payload
-  void inputAAC::getNext(size_t idx){
+  void InputAAC::getNext(size_t idx){
     //packets should be initialised to null to ensure termination
     thisPacket.null();
 
@@ -294,7 +294,7 @@ namespace Mist{
    // Seeks to the filePos 
    // @param <seekTime> timestamp of the DTSH entry containing required file pos info
    // @param <idx> trackID of the AAC track
-  void inputAAC::seek(uint64_t seekTime, size_t idx){
+  void InputAAC::seek(uint64_t seekTime, size_t idx){
     if (audioTrack == INVALID_TRACK_ID){
       std::set<size_t> trks = meta.getValidTracks();
       if (trks.size()){

--- a/src/input/input_aac.h
+++ b/src/input/input_aac.h
@@ -4,10 +4,10 @@
 #include <mist/urireader.h>
 
 namespace Mist{
-  class inputAAC : public Input{
+  class InputAAC : public Input{
   public:
-    inputAAC(Util::Config *cfg);
-    ~inputAAC();
+    InputAAC(Util::Config *cfg);
+    ~InputAAC();
 
   protected:
     // Private Functions
@@ -24,4 +24,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputAAC mistIn;
+typedef Mist::InputAAC mistIn;

--- a/src/input/input_av.cpp
+++ b/src/input/input_av.cpp
@@ -11,7 +11,7 @@
 #include "input_av.h"
 
 namespace Mist{
-  inputAV::inputAV(Util::Config *cfg) : Input(cfg){
+  InputAV::InputAV(Util::Config *cfg) : Input(cfg){
     pFormatCtx = 0;
     capa["name"] = "AV";
     capa["desc"] =
@@ -37,11 +37,11 @@ namespace Mist{
     }
   }
 
-  inputAV::~inputAV(){
+  InputAV::~InputAV(){
     if (pFormatCtx){avformat_close_input(&pFormatCtx);}
   }
 
-  bool inputAV::checkArguments(){
+  bool InputAV::checkArguments(){
     if (config->getString("input") == "-"){
       Util::logExitReason(ER_FORMAT_SPECIFIC, "Input from stdin not yet supported");
       return false;
@@ -60,7 +60,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputAV::preRun(){
+  bool InputAV::preRun(){
     // make sure all av inputs are registered properly, just in case
     // the constructor already does this, but under windows it doesn't remember that it has.
     // Very sad, that. We may need to get windows some medication for it.
@@ -94,7 +94,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputAV::readHeader(){
+  bool InputAV::readHeader(){
     if (!meta || (needsLock() && isSingular())){
       meta.reInit(isSingular() ? streamName : "");
     }
@@ -167,7 +167,7 @@ namespace Mist{
     return true;
   }
 
-  void inputAV::getNext(size_t wantIdx){
+  void InputAV::getNext(size_t wantIdx){
     AVPacket packet;
     while (av_read_frame(pFormatCtx, &packet) >= 0){
       // filter tracks we don't care about
@@ -198,7 +198,7 @@ namespace Mist{
     Util::logExitReason(ER_UNKNOWN, "getNext failed");
   }
 
-  void inputAV::seek(uint64_t seekTime, size_t idx){
+  void InputAV::seek(uint64_t seekTime, size_t idx){
     int stream_index = av_find_default_stream_index(pFormatCtx);
     // Convert ts to frame
     unsigned long long reseekTime =

--- a/src/input/input_av.h
+++ b/src/input/input_av.h
@@ -13,10 +13,10 @@ extern "C"{
 }
 
 namespace Mist{
-  class inputAV : public Input{
+  class InputAV : public Input{
   public:
-    inputAV(Util::Config *cfg);
-    ~inputAV();
+    InputAV(Util::Config *cfg);
+    ~InputAV();
 
   protected:
     // Private Functions
@@ -31,4 +31,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputAV mistIn;
+typedef Mist::InputAV mistIn;

--- a/src/input/input_balancer.cpp
+++ b/src/input/input_balancer.cpp
@@ -6,7 +6,7 @@
 #include <mist/url.h>
 
 namespace Mist{
-  inputBalancer::inputBalancer(Util::Config *cfg) : Input(cfg){
+  InputBalancer::InputBalancer(Util::Config *cfg) : Input(cfg){
     capa["name"] = "Balancer";
     capa["desc"] =
         "The load balancer input restarts itself as the input a load balancer tells it it should "
@@ -82,7 +82,7 @@ namespace Mist{
     capa["optional"]["segmentsize"]["default"] = 5000;
   }
 
-  int inputBalancer::boot(int argc, char *argv[]){
+  int InputBalancer::boot(int argc, char *argv[]){
     if (!config->parseArgs(argc, argv)){return 1;}
     if (config->getBool("json")){return Input::boot(argc, argv);}
 

--- a/src/input/input_balancer.h
+++ b/src/input/input_balancer.h
@@ -2,9 +2,9 @@
 #include <mist/dtsc.h>
 
 namespace Mist{
-  class inputBalancer : public Input{
+  class InputBalancer : public Input{
   public:
-    inputBalancer(Util::Config *cfg);
+    InputBalancer(Util::Config *cfg);
     int boot(int argc, char *argv[]);
 
   protected:
@@ -13,4 +13,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputBalancer mistIn;
+typedef Mist::InputBalancer mistIn;

--- a/src/input/input_buffer.cpp
+++ b/src/input/input_buffer.cpp
@@ -25,7 +25,7 @@
 /*LTS-END*/
 
 namespace Mist{
-  inputBuffer::inputBuffer(Util::Config *cfg) : Input(cfg){
+  InputBuffer::InputBuffer(Util::Config *cfg) : Input(cfg){
     firstProcTime = 0;
     lastProcTime = 0;
     allProcsRunning = false;
@@ -136,7 +136,7 @@ namespace Mist{
     resumeMode = false;
   }
 
-  inputBuffer::~inputBuffer(){
+  InputBuffer::~InputBuffer(){
     config->is_active = false;
     if (liveMeta){
       liveMeta->unlink();
@@ -146,7 +146,7 @@ namespace Mist{
   }
 
   /// Cleans up any left-over data for the current stream
-  void inputBuffer::onCrash(){
+  void InputBuffer::onCrash(){
     WARN_MSG("Buffer crashed. Cleaning.");
     streamName = config->getString("streamname");
 
@@ -185,7 +185,7 @@ namespace Mist{
   /// FULL, EMPTY, DRY or RECOVER (depending on current state)
   /// Detected issues in string format, or empty string if no issues
   /// ~~~~~~~~~~~~~~~
-  void inputBuffer::updateMeta(){
+  void InputBuffer::updateMeta(){
     if (!M){
       Util::logExitReason(ER_SHM_LOST, "Lost connection to metadata");
       return;
@@ -262,7 +262,7 @@ namespace Mist{
   /// * first fragment hasn't been at least lastms-firstms ms in buffer
   /// * less than 8 times the biggest fragment duration is buffered
   /// If a key was deleted and the first buffered data page is no longer used, it is deleted also.
-  bool inputBuffer::removeKey(size_t tid){
+  bool InputBuffer::removeKey(size_t tid){
     DTSC::Keys keys(M.keys(tid));
     // If this track is empty, abort
     if (!keys.getValidCount()){return false;}
@@ -290,7 +290,7 @@ namespace Mist{
     return meta.removeFirstKey(tid);
   }
 
-  void inputBuffer::finish(){
+  void InputBuffer::finish(){
     if (M.getValidTracks().size()){
       /*LTS-START*/
       if (M.getBufferWindow()){
@@ -306,7 +306,7 @@ namespace Mist{
     updateMeta();
   }
 
-  void inputBuffer::removeTrack(size_t tid){
+  void InputBuffer::removeTrack(size_t tid){
     size_t lastUser = users.recordCount();
     for (size_t i = 0; i < lastUser; ++i){
       if (users.getStatus(i) == COMM_STATUS_INVALID){continue;}
@@ -330,7 +330,7 @@ namespace Mist{
     /*LTS-END*/
   }
 
-  void inputBuffer::removeUnused(){
+  void InputBuffer::removeUnused(){
     meta.reloadReplacedPagesIfNeeded();
     if (!meta){
       return;
@@ -433,7 +433,7 @@ namespace Mist{
     updateMeta();
   }
 
-  void inputBuffer::userLeadIn(){
+  void InputBuffer::userLeadIn(){
     meta.reloadReplacedPagesIfNeeded();
     /*LTS-START*/
     // Reload the configuration to make sure we stay up to date with changes through the api
@@ -475,7 +475,7 @@ namespace Mist{
     }
     hasPush = false;
   }
-  void inputBuffer::userOnActive(size_t id){
+  void InputBuffer::userOnActive(size_t id){
     ///\todo Add tracing of earliest watched keys, to prevent data going out of memory for
     /// still-watching viewers
     if (!(users.getStatus(id) & COMM_STATUS_DISCONNECT) && (users.getStatus(id) & COMM_STATUS_SOURCE)){
@@ -486,7 +486,7 @@ namespace Mist{
 
     if (!(users.getStatus(id) & COMM_STATUS_DONOTTRACK)){++connectedUsers;}
   }
-  void inputBuffer::userOnDisconnect(size_t id){
+  void InputBuffer::userOnDisconnect(size_t id){
     if (sourcePids.count(id)){
       if (!resumeMode){
         INFO_MSG("Disconnected track %zu", sourcePids[id]);
@@ -498,7 +498,7 @@ namespace Mist{
       sourcePids.erase(id);
     }
   }
-  void inputBuffer::userLeadOut(){
+  void InputBuffer::userLeadOut(){
     if (config->is_active && streamStatus){
       streamStatus.mapped[0] = (hasPush && allProcsRunning) ? STRMSTAT_READY : STRMSTAT_WAIT;
     }
@@ -526,7 +526,7 @@ namespace Mist{
     /*LTS-END*/
   }
 
-  uint64_t inputBuffer::retrieveSetting(DTSC::Scan &streamCfg, const std::string &setting,
+  uint64_t InputBuffer::retrieveSetting(DTSC::Scan &streamCfg, const std::string &setting,
                                         const std::string &option){
     std::string opt = (option == "" ? setting : option);
     // If stream is not configured, use commandline option
@@ -537,7 +537,7 @@ namespace Mist{
     return config->getOption(opt, true)[0u].asInt();
   }
 
-  bool inputBuffer::preRun(){
+  bool InputBuffer::preRun(){
     // This function gets run periodically to make sure runtime updates of the config get parsed.
     Util::Procs::kill_timeout = 5;
     std::string strName = config->getString("streamname");
@@ -602,7 +602,7 @@ namespace Mist{
     return true;
   }
 
-  uint64_t inputBuffer::findTrack(const std::string &trackVal){
+  uint64_t InputBuffer::findTrack(const std::string &trackVal){
     std::set<size_t> validTracks = M.getValidTracks();
     if (!validTracks.size()){
       return INVALID_TRACK_ID;
@@ -646,7 +646,7 @@ namespace Mist{
 
   /*LTS-START*/
   /// Checks if all processes are running, starts them if needed, stops them if needed
-  void inputBuffer::checkProcesses(const JSON::Value &procs){
+  void InputBuffer::checkProcesses(const JSON::Value &procs){
     allProcsRunning = true;
     if (!M.getValidTracks().size()){return;}
     std::set<std::string> newProcs;

--- a/src/input/input_buffer.h
+++ b/src/input/input_buffer.h
@@ -4,10 +4,10 @@
 #include <mist/shared_memory.h>
 
 namespace Mist{
-  class inputBuffer : public Input{
+  class InputBuffer : public Input{
   public:
-    inputBuffer(Util::Config *cfg);
-    ~inputBuffer();
+    InputBuffer(Util::Config *cfg);
+    ~InputBuffer();
     void onCrash();
 
   private:
@@ -59,4 +59,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputBuffer mistIn;
+typedef Mist::InputBuffer mistIn;

--- a/src/input/input_dtsc.cpp
+++ b/src/input/input_dtsc.cpp
@@ -13,7 +13,7 @@
 #include "input_dtsc.h"
 
 namespace Mist{
-  inputDTSC::inputDTSC(Util::Config *cfg) : Input(cfg){
+  InputDTSC::InputDTSC(Util::Config *cfg) : Input(cfg){
     capa["name"] = "DTSC";
     capa["desc"] = "Load DTSC files as Video on Demand sources, or dtsc:// URLs from other "
                    "instances for live sources. This is the optimal method to pull live "
@@ -66,7 +66,7 @@ namespace Mist{
     lockNeeded = false;
   }
 
-  bool inputDTSC::needsLock(){
+  bool InputDTSC::needsLock(){
     if (!lockCache){
       lockNeeded =
           config->getString("input").substr(0, 7) != "dtsc://" && config->getString("input") != "-";
@@ -135,7 +135,7 @@ namespace Mist{
     }
   }
 
-  void inputDTSC::parseStreamHeader(){
+  void InputDTSC::parseStreamHeader(){
     while (srcConn.connected() && config->is_active){
       srcConn.spool();
       if (!srcConn.Received().available(8)){
@@ -176,7 +176,7 @@ namespace Mist{
     }
   }
 
-  bool inputDTSC::openStreamSource(){
+  bool InputDTSC::openStreamSource(){
     std::string source = config->getString("input");
     if (source == "-"){
       srcConn.open(fileno(stdout), fileno(stdin));
@@ -204,9 +204,9 @@ namespace Mist{
     return true;
   }
 
-  void inputDTSC::closeStreamSource(){srcConn.close();}
+  void InputDTSC::closeStreamSource(){srcConn.close();}
 
-  bool inputDTSC::checkArguments(){
+  bool InputDTSC::checkArguments(){
     if (!needsLock()){return true;}
     if (!config->getString("streamname").size()){
       if (config->getString("output") == "-"){
@@ -230,12 +230,12 @@ namespace Mist{
     return true;
   }
 
-  bool inputDTSC::needHeader(){
+  bool InputDTSC::needHeader(){
     if (!needsLock()){return false;}
     return Input::needHeader();
   }
 
-  bool inputDTSC::readHeader(){
+  bool InputDTSC::readHeader(){
     if (!F){
       Util::logExitReason(ER_READ_START_FAILURE, "Reading header for '%s' failed: Could not open input stream", config->getString("input").c_str());
       return false;
@@ -272,7 +272,7 @@ namespace Mist{
     return meta;
   }
 
-  void inputDTSC::getNext(size_t idx){
+  void InputDTSC::getNext(size_t idx){
     if (!needsLock()){
       getNextFromStream(idx);
       return;
@@ -336,7 +336,7 @@ namespace Mist{
     fseek(F, thisPos.bytePos, SEEK_SET);
   }
 
-  void inputDTSC::getNextFromStream(size_t idx){
+  void InputDTSC::getNextFromStream(size_t idx){
     thisPacket.reInit(srcConn);
     while (config->is_active){
       if (thisPacket.getVersion() == DTSC::DTCM){
@@ -415,7 +415,7 @@ namespace Mist{
     }
   }
 
-  void inputDTSC::seek(uint64_t seekTime, size_t idx){
+  void InputDTSC::seek(uint64_t seekTime, size_t idx){
     currentPositions.clear();
     if (idx != INVALID_TRACK_ID){
       seekNext(seekTime, idx, true);
@@ -427,7 +427,7 @@ namespace Mist{
     }
   }
 
-  void inputDTSC::seekNext(uint64_t ms, size_t trackIdx, bool forceSeek){
+  void InputDTSC::seekNext(uint64_t ms, size_t trackIdx, bool forceSeek){
     seekPos tmpPos;
     tmpPos.trackID = trackIdx;
     if (!forceSeek && thisPacket && ms >= thisPacket.getTime() && trackIdx >= thisPacket.getTrackId()){

--- a/src/input/input_dtsc.h
+++ b/src/input/input_dtsc.h
@@ -22,9 +22,9 @@ namespace Mist{
                        ///< associated with.
   };
 
-  class inputDTSC : public Input{
+  class InputDTSC : public Input{
   public:
-    inputDTSC(Util::Config *cfg);
+    InputDTSC(Util::Config *cfg);
     bool needsLock();
 
     virtual std::string getConnectedBinHost(){
@@ -61,4 +61,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputDTSC mistIn;
+typedef Mist::InputDTSC mistIn;

--- a/src/input/input_dtsccrypt.cpp
+++ b/src/input/input_dtsccrypt.cpp
@@ -14,7 +14,7 @@
 #include <ctime>
 
 namespace Mist{
-  inputDTSC::inputDTSC(Util::Config *cfg) : Input(cfg){
+  InputDTSC::InputDTSC(Util::Config *cfg) : Input(cfg){
     capa["name"] = "DTSC";
     capa["desc"] = "Enables DTSC Input";
     capa["priority"] = 9;
@@ -52,7 +52,7 @@ namespace Mist{
     srand(time(NULL));
   }
 
-  bool inputDTSC::checkArguments(){
+  bool InputDTSC::checkArguments(){
     key = Encodings::Base64::decode(config->getString("key"));
     if (key == ""){
       if (config->getString("keyseed") == "" || config->getString("keyid") == ""){
@@ -90,7 +90,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputDTSC::readHeader(){
+  bool InputDTSC::readHeader(){
     if (!inFile){
       Util::logExitReason(ER_READ_START_FAILURE, "Reading header for '%s' failed: Could not open input stream", config->getString("input").c_str());
       return false;
@@ -110,7 +110,7 @@ namespace Mist{
     return true;
   }
 
-  void inputDTSC::getNext(bool smart){
+  void InputDTSC::getNext(bool smart){
     if (smart){
       inFile.seekNext();
     }else{
@@ -135,13 +135,13 @@ namespace Mist{
     Encryption::encryptPlayReady(thisPacket, myMeta.tracks[tid].codec, iVec, key.data());
   }
 
-  void inputDTSC::seek(int seekTime){
+  void InputDTSC::seek(int seekTime){
     inFile.seek_time(seekTime);
     initialTime = 0;
     playUntil = 0;
   }
 
-  void inputDTSC::trackSelect(std::string trackSpec){
+  void InputDTSC::trackSelect(std::string trackSpec){
     selectedTracks.clear();
     long long unsigned int index;
     while (trackSpec != ""){

--- a/src/input/input_dtsccrypt.h
+++ b/src/input/input_dtsccrypt.h
@@ -2,9 +2,9 @@
 #include <mist/dtsc.h>
 
 namespace Mist{
-  class inputDTSC : public Input{
+  class InputDTSC : public Input{
   public:
-    inputDTSC(Util::Config *cfg);
+    InputDTSC(Util::Config *cfg);
 
   protected:
     // Private Functions
@@ -21,4 +21,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputDTSC mistIn;
+typedef Mist::InputDTSC mistIn;

--- a/src/input/input_flac.cpp
+++ b/src/input/input_flac.cpp
@@ -16,7 +16,7 @@
 #include <mist/flac.h>
 
 namespace Mist{
-  inputFLAC::inputFLAC(Util::Config *cfg) : Input(cfg){
+  InputFLAC::InputFLAC(Util::Config *cfg) : Input(cfg){
     capa["name"] = "FLAC";
     capa["desc"] = "Allows loading FLAC files for Audio on Demand.";
     capa["source_match"] = "/*.flac";
@@ -36,9 +36,9 @@ namespace Mist{
     tNum = INVALID_TRACK_ID;
   }
 
-  inputFLAC::~inputFLAC(){}
+  InputFLAC::~InputFLAC(){}
 
-  bool inputFLAC::checkArguments(){
+  bool InputFLAC::checkArguments(){
     if (config->getString("input") == "-"){
       Util::logExitReason(ER_FORMAT_SPECIFIC, "Input from stdin not yet supported");
       return false;
@@ -57,7 +57,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputFLAC::preRun(){
+  bool InputFLAC::preRun(){
     inFile = fopen(config->getString("input").c_str(), "r");
     if (!inFile){
       Util::logExitReason(ER_READ_START_FAILURE, "Opening input '%s' failed", config->getString("input").c_str());
@@ -66,7 +66,7 @@ namespace Mist{
     return true;
   }
 
-  void inputFLAC::stripID3tag(){
+  void InputFLAC::stripID3tag(){
     char header[10];
     fread(header, 10, 1, inFile); // Read a 10 byte header
     if (header[0] == 'I' || header[1] == 'D' || header[2] == '3'){
@@ -81,7 +81,7 @@ namespace Mist{
     }
   }
 
-  bool inputFLAC::readMagicPacket(){
+  bool InputFLAC::readMagicPacket(){
     char magic[4];
     if (fread(magic, 4, 1, inFile) != 1){
       Util::logExitReason(ER_FORMAT_SPECIFIC, "Could not read magic word - aborting!");
@@ -97,7 +97,7 @@ namespace Mist{
     return false;
   }
 
-  bool inputFLAC::readHeader(){
+  bool InputFLAC::readHeader(){
     if (!inFile){
       Util::logExitReason(ER_READ_START_FAILURE, "Opening input '%s' failed", config->getString("input").c_str());
       return false;
@@ -206,7 +206,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputFLAC::fillBuffer(size_t size){
+  bool InputFLAC::fillBuffer(size_t size){
     if (feof(inFile)){
       INFO_MSG("EOF");
       return flacBuffer.size();
@@ -229,7 +229,7 @@ namespace Mist{
     return flacBuffer.size();
   }
 
-  void inputFLAC::getNext(size_t idx){
+  void InputFLAC::getNext(size_t idx){
     while (!stopProcessing){
       blockSize = M.inputLocalVars["blockSize"].asInt();
 
@@ -323,7 +323,7 @@ namespace Mist{
     return;
   }
 
-  void inputFLAC::seek(uint64_t seekTime, size_t idx){
+  void InputFLAC::seek(uint64_t seekTime, size_t idx){
     uint64_t mainTrack = M.mainTrack();
     blockSize = M.inputLocalVars["blockSize"].asInt();
     sampleRate = meta.getRate(mainTrack);

--- a/src/input/input_flac.h
+++ b/src/input/input_flac.h
@@ -3,10 +3,10 @@
 #include <mist/dtsc.h>
 
 namespace Mist{
-  class inputFLAC : public Input{
+  class InputFLAC : public Input{
   public:
-    inputFLAC(Util::Config *cfg);
-    ~inputFLAC();
+    InputFLAC(Util::Config *cfg);
+    ~InputFLAC();
 
   protected:
     bool checkArguments();
@@ -45,4 +45,4 @@ namespace Mist{
 
 }// namespace Mist
 
-typedef Mist::inputFLAC mistIn;
+typedef Mist::InputFLAC mistIn;

--- a/src/input/input_flv.cpp
+++ b/src/input/input_flv.cpp
@@ -15,7 +15,7 @@
 #include "input_flv.h"
 
 namespace Mist{
-  inputFLV::inputFLV(Util::Config *cfg) : Input(cfg){
+  InputFLV::InputFLV(Util::Config *cfg) : Input(cfg){
     capa["name"] = "FLV";
     capa["desc"] = "Allows loading FLV files for Video on Demand.";
     capa["source_match"] = "/*.flv";
@@ -28,9 +28,9 @@ namespace Mist{
     capa["codecs"]["audio"].append("MP3");
   }
 
-  inputFLV::~inputFLV(){}
+  InputFLV::~InputFLV(){}
 
-  bool inputFLV::checkArguments(){
+  bool InputFLV::checkArguments(){
     if (config->getString("input") == "-"){
       Util::logExitReason(ER_FORMAT_SPECIFIC, "Input from stdin not yet supported");
       return false;
@@ -49,7 +49,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputFLV::preRun(){
+  bool InputFLV::preRun(){
     // open File
     inFile = fopen(config->getString("input").c_str(), "r");
     if (!inFile){
@@ -67,7 +67,7 @@ namespace Mist{
   /// Overrides the default keepRunning function to shut down
   /// if the file disappears or changes, by polling the file's mtime.
   /// If neither applies, calls the original function.
-  bool inputFLV::keepRunning(){
+  bool InputFLV::keepRunning(){
     struct stat statData;
     if (stat(config->getString("input").c_str(), &statData) == -1){
       INFO_MSG("Shutting down because input file disappeared");
@@ -80,7 +80,7 @@ namespace Mist{
     return Input::keepRunning();
   }
 
-  bool inputFLV::readHeader(){
+  bool InputFLV::readHeader(){
     if (!inFile){
       Util::logExitReason(ER_READ_START_FAILURE, "Reading header for '%s' failed: Could not open input stream", config->getString("input").c_str());
       return false;
@@ -116,7 +116,7 @@ namespace Mist{
     return true;
   }
 
-  void inputFLV::getNext(size_t idx){
+  void InputFLV::getNext(size_t idx){
     uint64_t lastBytePos = Util::ftell(inFile);
     if (idx != INVALID_TRACK_ID){
       uint8_t targetTag = 0x08;
@@ -165,7 +165,7 @@ namespace Mist{
     }
   }
 
-  void inputFLV::seek(uint64_t seekTime, size_t idx){
+  void InputFLV::seek(uint64_t seekTime, size_t idx){
     // We will seek to the corresponding keyframe of the video track if selected, otherwise audio
     // keyframe. Flv files are never multi-track, so track 1 is video, track 2 is audio.
     size_t seekTrack = (idx == INVALID_TRACK_ID ? M.mainTrack() : idx);

--- a/src/input/input_flv.h
+++ b/src/input/input_flv.h
@@ -3,10 +3,10 @@
 #include <mist/flv_tag.h>
 
 namespace Mist{
-  class inputFLV : public Input{
+  class InputFLV : public Input{
   public:
-    inputFLV(Util::Config *cfg);
-    ~inputFLV();
+    InputFLV(Util::Config *cfg);
+    ~InputFLV();
 
   protected:
     // Private Functions
@@ -22,4 +22,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputFLV mistIn;
+typedef Mist::InputFLV mistIn;

--- a/src/input/input_folder.cpp
+++ b/src/input/input_folder.cpp
@@ -7,7 +7,7 @@
 #include "input_folder.h"
 
 namespace Mist{
-  inputFolder::inputFolder(Util::Config *cfg) : Input(cfg){
+  InputFolder::InputFolder(Util::Config *cfg) : Input(cfg){
     capa["name"] = "Folder";
     capa["desc"] =
         "The folder input will make available all supported files in the given folder as streams "
@@ -21,7 +21,7 @@ namespace Mist{
     capa["morphic"] = 1;
   }
 
-  int inputFolder::boot(int argc, char *argv[]){
+  int InputFolder::boot(int argc, char *argv[]){
     if (!config->parseArgs(argc, argv)){return 1;}
     if (config->getBool("json")){return Input::boot(argc, argv);}
 

--- a/src/input/input_folder.h
+++ b/src/input/input_folder.h
@@ -2,9 +2,9 @@
 #include <mist/dtsc.h>
 
 namespace Mist{
-  class inputFolder : public Input{
+  class InputFolder : public Input{
   public:
-    inputFolder(Util::Config *cfg);
+    InputFolder(Util::Config *cfg);
     int boot(int argc, char *argv[]);
 
   protected:
@@ -15,4 +15,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputFolder mistIn;
+typedef Mist::InputFolder mistIn;

--- a/src/input/input_hls.cpp
+++ b/src/input/input_hls.cpp
@@ -140,11 +140,11 @@ namespace Mist{
 
   // These are used in the HTTP::Downloader callback, to prevent timeouts when downloading
   // segments/playlists.
-  inputHLS *self = 0;
+  InputHLS *self = 0;
   bool callbackFunc(uint8_t){return self->callback();}
 
   /// Called by the global callbackFunc, to prevent timeouts
-  bool inputHLS::callback(){
+  bool InputHLS::callback(){
     keepAlive();
     return config->is_active;
   }
@@ -723,7 +723,7 @@ namespace Mist{
   }
 
   /// Constructor of HLS Input
-  inputHLS::inputHLS(Util::Config *cfg) : Input(cfg){
+  InputHLS::InputHLS(Util::Config *cfg) : Input(cfg){
     zUTC = nUTC = 0;
     self = this;
     streamIsLive = true; //< default to sliding window playlist
@@ -783,11 +783,11 @@ namespace Mist{
     inFile = NULL;
   }
 
-  inputHLS::~inputHLS(){
+  InputHLS::~InputHLS(){
     if (inFile){fclose(inFile);}
   }
 
-  bool inputHLS::checkArguments(){
+  bool InputHLS::checkArguments(){
     config->is_active = true;
     if (config->getString("input") == "-"){
       return false;
@@ -806,7 +806,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputHLS::readExistingHeader(){
+  bool InputHLS::readExistingHeader(){
     if (!Input::readExistingHeader()){
       INFO_MSG("Could not read existing header, regenerating");
       return false;
@@ -900,12 +900,12 @@ namespace Mist{
     return true;
   }
 
-  void inputHLS::parseStreamHeader(){
+  void InputHLS::parseStreamHeader(){
     streamIsVOD = false;
     readHeader();
   }
 
-  bool inputHLS::readHeader(){
+  bool InputHLS::readHeader(){
     // to analyse and extract data
     TS::Packet packet; 
     char *data;
@@ -1038,7 +1038,7 @@ namespace Mist{
   }
 
   /// Sets inputLocalVars based on data ingested
-  void inputHLS::injectLocalVars(){
+  void InputHLS::injectLocalVars(){
     meta.inputLocalVars.null();
     meta.inputLocalVars["version"] = 4;
 
@@ -1080,7 +1080,7 @@ namespace Mist{
   /// \brief Parses new segments added to playlist files as live data
   /// \param segmentIndex: the index of the segment in the current playlist
   /// \return True if the segment has been buffered successfully
-  bool inputHLS::parseSegmentAsLive(uint64_t segmentIndex){
+  bool InputHLS::parseSegmentAsLive(uint64_t segmentIndex){
     bool hasOffset = false;
     bool hasPacket = false;
     uint64_t bufferTime = config->getInteger("pagetimeout");
@@ -1187,12 +1187,12 @@ namespace Mist{
     return true;
   }
 
-  void inputHLS::streamMainLoop(){
+  void InputHLS::streamMainLoop(){
     parseLivePoint();
   }
 
   // Removes any metadata which is no longer and the playlist or buffered in memory
-  void inputHLS::updateMeta(){
+  void InputHLS::updateMeta(){
     // EVENT and VOD type playlists should never segments disappear from the start
     // Only LIVE (sliding-window) type playlists should execute updateMeta()
     if (streamIsVOD || !streamIsLive){
@@ -1224,7 +1224,7 @@ namespace Mist{
     }
   }
 
-  void inputHLS::parseLivePoint(){
+  void InputHLS::parseLivePoint(){
     uint64_t maxTime = Util::bootMS() + 500;
     // Update all playlists to make sure listEntries contains all live segments
     for (std::map<uint64_t, Playlist>::iterator pListIt = playlistMapping.begin();
@@ -1279,16 +1279,16 @@ namespace Mist{
   }
 
   /// \brief Override userLeadOut to buffer new data as live packets
-  void inputHLS::userLeadOut(){
+  void InputHLS::userLeadOut(){
     Input::userLeadOut();
     if (streamIsLive){
       parseLivePoint();
     }
   }
 
-  bool inputHLS::openStreamSource(){return true;}
+  bool InputHLS::openStreamSource(){return true;}
 
-  void inputHLS::getNext(size_t idx){
+  void InputHLS::getNext(size_t idx){
     INSANE_MSG("Getting next");
     uint32_t tid = 0;
     bool finished = false;
@@ -1390,7 +1390,7 @@ namespace Mist{
   }
 
   // Note: bpos is overloaded here for playlist entry!
-  void inputHLS::seek(uint64_t seekTime, size_t idx){
+  void InputHLS::seek(uint64_t seekTime, size_t idx){
     if (idx == INVALID_TRACK_ID){return;}
     plsTimeOffset.clear();
     plsLastTime.clear();
@@ -1456,7 +1456,7 @@ namespace Mist{
   /// \param currentPlaylist: the ID of the playlist we are currently trying to parse
   /// \param nUTC: Defaults to 0. If larger than 0, sync the timestamp based on this value and zUTC
   /// \return the (modified) packetTime, used for meta.updates and buffering packets
-  uint64_t inputHLS::getPacketTime(uint64_t packetTime, uint64_t tid, uint64_t currentPlaylist, uint64_t nUTC){
+  uint64_t InputHLS::getPacketTime(uint64_t packetTime, uint64_t tid, uint64_t currentPlaylist, uint64_t nUTC){
     INSANE_MSG("Calculating adjusted packet time for track %" PRIu64 " on playlist %" PRIu64 " with current timestamp %" PRIu64 ". UTC timestamp is %" PRIu64, tid, currentPlaylist, packetTime, nUTC);
     uint64_t newTime = packetTime;
 
@@ -1519,7 +1519,7 @@ namespace Mist{
   /// \brief Returns the packet ID corresponding to this playlist and track
   /// \param trackId: the trackid corresponding to this track and playlist
   /// \param currentPlaylist: the ID of the playlist we are currently trying to parse
-  uint64_t inputHLS::getPacketID(uint64_t currentPlaylist, uint64_t trackId){
+  uint64_t InputHLS::getPacketID(uint64_t currentPlaylist, uint64_t trackId){
     uint64_t packetId = pidMapping[(((uint64_t)currentPlaylist) << 32) + trackId];
     if (packetId == 0){
       pidMapping[(((uint64_t)currentPlaylist) << 32) + trackId] = pidCounter;
@@ -1530,11 +1530,11 @@ namespace Mist{
     return packetId;
   }
 
-  uint64_t inputHLS::getOriginalTrackId(uint32_t playlistId, uint32_t id){
+  uint64_t InputHLS::getOriginalTrackId(uint32_t playlistId, uint32_t id){
     return pidMapping[(((uint64_t)playlistId) << 32) + id];
   }
 
-  uint32_t inputHLS::getMappedTrackId(uint64_t id){
+  uint32_t InputHLS::getMappedTrackId(uint64_t id){
     static uint64_t lastIn = id;
     static uint32_t lastOut = (pidMappingR[id] & 0xFFFFFFFFull);
     if (lastIn != id){
@@ -1544,7 +1544,7 @@ namespace Mist{
     return lastOut;
   }
 
-  uint32_t inputHLS::getMappedTrackPlaylist(uint64_t id){
+  uint32_t InputHLS::getMappedTrackPlaylist(uint64_t id){
     if (!pidMappingR.count(id)){
       FAIL_MSG("No mapping found for track ID %" PRIu64, id);
       return 0;
@@ -1559,7 +1559,7 @@ namespace Mist{
   }
 
   /// Parses the main playlist, possibly containing variants.
-  bool inputHLS::initPlaylist(const std::string &uri, bool fullInit){
+  bool InputHLS::initPlaylist(const std::string &uri, bool fullInit){
     // Used to set zUTC, in case the first EXT-X-PROGRAM-DATE-TIME does not appear before the first segment
     float timestampSum = 0;
     bool isRegularPls = false;
@@ -1741,7 +1741,7 @@ namespace Mist{
   }
 
   /// Function for reading every playlist.
-  bool inputHLS::readPlaylist(const HTTP::URL &uri, const  std::string & relurl, bool fullInit){
+  bool InputHLS::readPlaylist(const HTTP::URL &uri, const  std::string & relurl, bool fullInit){
     std::string urlBuffer;
     // Wildcard streams can have a ' ' in the name, which getUrl converts to a '+'
     if (uri.isLocalPath()){
@@ -1761,7 +1761,7 @@ namespace Mist{
 
   /// Read next .ts file from the playlist. (from the list of entries which needs
   /// to be processed)
-  bool inputHLS::readNextFile(){
+  bool InputHLS::readNextFile(){
     tsStream.clear();
 
     playListEntries ntry;
@@ -1808,7 +1808,7 @@ namespace Mist{
   /// return the playlist id from which we need to read the first upcoming segment
   /// by timestamp.
   /// this will keep the playlists in sync while reading segments.
-  size_t inputHLS::firstSegment(){
+  size_t InputHLS::firstSegment(){
     // Only one selected? Immediately return the right playlist.
     if (!streamIsLive){return getMappedTrackPlaylist(M.getID(userSelect.begin()->first));}
     uint64_t firstTimeStamp = 0;
@@ -1831,7 +1831,7 @@ namespace Mist{
     return tmpId;
   }
 
-  void inputHLS::finish(){
+  void InputHLS::finish(){
     if (streamIsLive){ //< Already generated from readHeader
       INFO_MSG("Writing updated header to disk");
       injectLocalVars();
@@ -1840,7 +1840,7 @@ namespace Mist{
     Input::finish();
   }
 
-  void inputHLS::checkHeaderTimes(const HTTP::URL & streamFile){
+  void InputHLS::checkHeaderTimes(const HTTP::URL & streamFile){
     if (streamIsLive){return;} //< Since the playlist will likely be newer than the DTSH for live-dvr
     Input::checkHeaderTimes(streamFile);
   }

--- a/src/input/input_hls.h
+++ b/src/input/input_hls.h
@@ -106,10 +106,10 @@ namespace Mist{
 
   void playlistRunner(void *ptr);
 
-  class inputHLS : public Input{
+  class InputHLS : public Input{
   public:
-    inputHLS(Util::Config *cfg);
-    ~inputHLS();
+    InputHLS(Util::Config *cfg);
+    ~InputHLS();
     bool needsLock(){return !config->getBool("realtime");}
     bool openStreamSource();
     bool callback();
@@ -187,4 +187,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputHLS mistIn;
+typedef Mist::InputHLS mistIn;

--- a/src/input/input_ismv.cpp
+++ b/src/input/input_ismv.cpp
@@ -11,7 +11,7 @@
 #include "input_ismv.h"
 
 namespace Mist{
-  inputISMV::inputISMV(Util::Config *cfg) : Input(cfg){
+  InputISMV::InputISMV(Util::Config *cfg) : Input(cfg){
     capa["name"] = "ISMV";
     capa["desc"] = "This input allows you to stream ISMV Video on Demand files.";
     capa["source_match"] = "/*.ismv";
@@ -22,7 +22,7 @@ namespace Mist{
     inFile = 0;
   }
 
-  bool inputISMV::checkArguments(){
+  bool InputISMV::checkArguments(){
     if (config->getString("input") == "-"){
       Util::logExitReason(ER_FORMAT_SPECIFIC, "Input from stdin not yet supported");
       return false;
@@ -41,7 +41,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputISMV::preRun(){
+  bool InputISMV::preRun(){
     inFile = fopen(config->getString("input").c_str(), "r");
     if (!inFile){
       Util::logExitReason(ER_READ_START_FAILURE, "Opening input '%s' failed", config->getString("input").c_str());
@@ -50,7 +50,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputISMV::readHeader(){
+  bool InputISMV::readHeader(){
     if (!inFile){
       Util::logExitReason(ER_READ_START_FAILURE, "Reading header for '%s' failed: Could not open input stream", config->getString("input").c_str());
       return false;
@@ -97,7 +97,7 @@ namespace Mist{
     return true;
   }
 
-  void inputISMV::getNext(size_t idx){
+  void InputISMV::getNext(size_t idx){
     thisPacket.null();
 
     if (!buffered.size()){return;}
@@ -128,7 +128,7 @@ namespace Mist{
     if (idx != INVALID_TRACK_ID && thisPacket.getTrackId() != M.getID(idx)){getNext(idx);}
   }
 
-  void inputISMV::seek(uint64_t seekTime, size_t idx){
+  void InputISMV::seek(uint64_t seekTime, size_t idx){
     buffered.clear();
     lastKeyNum.clear();
 
@@ -152,7 +152,7 @@ namespace Mist{
     }
   }
 
-  void inputISMV::parseMoov(MP4::MOOV &moovBox){
+  void InputISMV::parseMoov(MP4::MOOV &moovBox){
     std::deque<MP4::TRAK> trak = moovBox.getChildren<MP4::TRAK>();
     for (std::deque<MP4::TRAK>::iterator it = trak.begin(); it != trak.end(); it++){
       size_t tNumber = meta.addTrack();
@@ -189,7 +189,7 @@ namespace Mist{
     }
   }
 
-  bool inputISMV::readMoofSkipMdat(size_t &tId, std::vector<MP4::trunSampleInformation> &trunSamples){
+  bool InputISMV::readMoofSkipMdat(size_t &tId, std::vector<MP4::trunSampleInformation> &trunSamples){
     tId = INVALID_TRACK_ID;
     trunSamples.clear();
 
@@ -222,7 +222,7 @@ namespace Mist{
     return true;
   }
 
-  void inputISMV::bufferFragmentData(size_t trackId, uint32_t keyNum){
+  void InputISMV::bufferFragmentData(size_t trackId, uint32_t keyNum){
     INFO_MSG("Bpos seek for %zu/%" PRIu32, trackId, keyNum);
     if (trackId == INVALID_TRACK_ID){return;}
     DTSC::Keys keys(M.keys(trackId));

--- a/src/input/input_ismv.h
+++ b/src/input/input_ismv.h
@@ -22,9 +22,9 @@ namespace Mist{
     std::string iVec;
   };
 
-  class inputISMV : public Input{
+  class InputISMV : public Input{
   public:
-    inputISMV(Util::Config *cfg);
+    InputISMV(Util::Config *cfg);
 
   protected:
     // Private Functions
@@ -47,4 +47,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputISMV mistIn;
+typedef Mist::InputISMV mistIn;

--- a/src/input/input_mp3.cpp
+++ b/src/input/input_mp3.cpp
@@ -13,7 +13,7 @@
 #include "input_mp3.h"
 
 namespace Mist{
-  inputMP3::inputMP3(Util::Config *cfg) : Input(cfg){
+  InputMP3::InputMP3(Util::Config *cfg) : Input(cfg){
     capa["name"] = "MP3";
     capa["desc"] = "This input allows you to stream MP3 Video on Demand files.";
     capa["source_match"] = "/*.mp3";
@@ -23,7 +23,7 @@ namespace Mist{
     timestamp = 0;
   }
 
-  bool inputMP3::checkArguments(){
+  bool InputMP3::checkArguments(){
     if (config->getString("input") == "-"){
       Util::logExitReason(ER_FORMAT_SPECIFIC, "Input from stdin not yet supported");
       return false;
@@ -42,7 +42,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputMP3::preRun(){
+  bool InputMP3::preRun(){
     // open File
     inFile = fopen(config->getString("input").c_str(), "r");
     if (!inFile){
@@ -52,7 +52,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputMP3::readHeader(){
+  bool InputMP3::readHeader(){
     if (!inFile){
       Util::logExitReason(ER_READ_START_FAILURE, "Reading header for '%s' failed: Could not open input stream", config->getString("input").c_str());
       return false;
@@ -94,7 +94,7 @@ namespace Mist{
     return true;
   }
 
-  void inputMP3::getNext(size_t idx){
+  void InputMP3::getNext(size_t idx){
     thisPacket.null();
     static char packHeader[3000];
     size_t filePos = ftell(inFile);
@@ -158,7 +158,7 @@ namespace Mist{
     timestamp += (sampleCount / (sampleRate / 1000));
   }
 
-  void inputMP3::seek(uint64_t seekTime, size_t idx){
+  void InputMP3::seek(uint64_t seekTime, size_t idx){
     idx = 0;
     DTSC::Keys keys(M.keys(idx));
     uint32_t keyNum = M.getKeyNumForTime(idx, seekTime);

--- a/src/input/input_mp3.h
+++ b/src/input/input_mp3.h
@@ -12,9 +12,9 @@ namespace Mist{
       {{0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256, -1},
        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, -1},
        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, -1}}};
-  class inputMP3 : public Input{
+  class InputMP3 : public Input{
   public:
-    inputMP3(Util::Config *cfg);
+    InputMP3(Util::Config *cfg);
 
   protected:
     // Private Functions
@@ -30,4 +30,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputMP3 mistIn;
+typedef Mist::InputMP3 mistIn;

--- a/src/input/input_mp4.cpp
+++ b/src/input/input_mp4.cpp
@@ -96,7 +96,7 @@ namespace Mist{
     initialised = true;
   }
 
-  mp4TrackHeader &inputMP4::headerData(size_t trackID){
+  mp4TrackHeader &InputMP4::headerData(size_t trackID){
     static mp4TrackHeader none;
     for (std::deque<mp4TrackHeader>::iterator it = trackHeaders.begin(); it != trackHeaders.end(); it++){
       if (it->trackId == trackID){return *it;}
@@ -104,7 +104,7 @@ namespace Mist{
     return none;
   }
 
-  inputMP4::inputMP4(Util::Config *cfg) : Input(cfg){
+  InputMP4::InputMP4(Util::Config *cfg) : Input(cfg){
     capa["name"] = "MP4";
     capa["desc"] = "This input allows streaming of MP4 files as Video on Demand.";
     capa["source_match"].append("/*.mp4");
@@ -125,7 +125,7 @@ namespace Mist{
     readPos = 0;
   }
 
-  bool inputMP4::checkArguments(){
+  bool InputMP4::checkArguments(){
     if (config->getString("input") == "-"){
       Util::logExitReason(ER_FORMAT_SPECIFIC, "Input from stdin not yet supported");
       return false;
@@ -145,7 +145,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputMP4::preRun(){
+  bool InputMP4::preRun(){
     // open File
     inFile.open(config->getString("input"));
     if (!inFile){
@@ -159,17 +159,17 @@ namespace Mist{
     return true;
   }
 
-  void inputMP4::dataCallback(const char *ptr, size_t size){readBuffer.append(ptr, size);}
-  size_t inputMP4::getDataCallbackPos() const{return readPos + readBuffer.size();}
+  void InputMP4::dataCallback(const char *ptr, size_t size){readBuffer.append(ptr, size);}
+  size_t InputMP4::getDataCallbackPos() const{return readPos + readBuffer.size();}
 
-  bool inputMP4::needHeader(){
+  bool InputMP4::needHeader(){
     //Attempt to read cache, but force calling of the readHeader function anyway
     bool r = Input::needHeader();
     if (!r){r = !readHeader();}
     return r;
   }
 
-  bool inputMP4::readHeader(){
+  bool InputMP4::readHeader(){
     if (!inFile){
       Util::logExitReason(ER_READ_START_FAILURE, "Reading header for '%s' failed: Could not open input stream", config->getString("input").c_str());
       return false;
@@ -493,7 +493,7 @@ namespace Mist{
     return true;
   }
 
-  void inputMP4::getNext(size_t idx){// get next part from track in stream
+  void InputMP4::getNext(size_t idx){// get next part from track in stream
     if (curPositions.empty()){
       thisPacket.null();
       return;
@@ -587,7 +587,7 @@ namespace Mist{
     }
   }
 
-  void inputMP4::seek(uint64_t seekTime, size_t idx){// seek to a point
+  void InputMP4::seek(uint64_t seekTime, size_t idx){// seek to a point
     nextKeyframe.clear();
     curPositions.clear();
     if (idx != INVALID_TRACK_ID){
@@ -600,7 +600,7 @@ namespace Mist{
     }
   }
 
-  void inputMP4::handleSeek(uint64_t seekTime, size_t idx){
+  void InputMP4::handleSeek(uint64_t seekTime, size_t idx){
     nextKeyframe[idx] = 0;
     mp4PartTime addPart;
     addPart.trackID = idx;

--- a/src/input/input_mp4.h
+++ b/src/input/input_mp4.h
@@ -70,9 +70,9 @@ namespace Mist{
     bool stco64;
   };
 
-  class inputMP4 : public Input, public Util::DataCallback {
+  class InputMP4 : public Input, public Util::DataCallback {
   public:
-    inputMP4(Util::Config *cfg);
+    InputMP4(Util::Config *cfg);
     virtual void dataCallback(const char *ptr, size_t size);
     virtual size_t getDataCallbackPos() const;
 
@@ -101,4 +101,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputMP4 mistIn;
+typedef Mist::InputMP4 mistIn;

--- a/src/input/input_ogg.cpp
+++ b/src/input/input_ogg.cpp
@@ -33,7 +33,7 @@ namespace Mist{
     return retval;
   }
 
-  inputOGG::inputOGG(Util::Config *cfg) : Input(cfg){
+  InputOGG::InputOGG(Util::Config *cfg) : Input(cfg){
     capa["name"] = "OGG";
     capa["desc"] = "This input allows streaming of OGG files as Video on Demand.";
     capa["source_match"] = "/*.ogg";
@@ -43,7 +43,7 @@ namespace Mist{
     capa["codecs"]["audio"].append("opus");
   }
 
-  bool inputOGG::checkArguments(){
+  bool InputOGG::checkArguments(){
     if (config->getString("input") == "-"){
       std::cerr << "Input from stream not yet supported" << std::endl;
       return false;
@@ -51,7 +51,7 @@ namespace Mist{
     return true;
   }
 
-  bool inputOGG::preRun(){
+  bool InputOGG::preRun(){
     // open File
     inFile = fopen(config->getString("input").c_str(), "r");
     if (!inFile){
@@ -62,7 +62,7 @@ namespace Mist{
   }
 
   ///\todo check if all trackID (tid) instances are replaced with bitstream serial numbers
-  void inputOGG::parseBeginOfStream(OGG::Page &bosPage){
+  void InputOGG::parseBeginOfStream(OGG::Page &bosPage){
     // long long int tid = snum2tid.size() + 1;
     size_t tid = bosPage.getBitstreamSerialNumber();
     size_t idx = M.trackIDToIndex(tid, getpid());
@@ -117,7 +117,7 @@ namespace Mist{
     }
   }
 
-  bool inputOGG::readHeader(){
+  bool InputOGG::readHeader(){
     meta.reInit(config->getString("streamname"), true);
     OGG::Page myPage;
     fseek(inFile, 0, SEEK_SET);
@@ -228,7 +228,7 @@ namespace Mist{
     return true;
   }
 
-  position inputOGG::seekFirstData(size_t idx){
+  position InputOGG::seekFirstData(size_t idx){
     fseek(inFile, 0, SEEK_SET);
     position res;
     res.time = 0;
@@ -272,7 +272,7 @@ namespace Mist{
     return res;
   }
 
-  void inputOGG::getNext(size_t idx){
+  void InputOGG::getNext(size_t idx){
     if (!currentPositions.size()){
       thisPacket.null();
       return;
@@ -362,7 +362,7 @@ namespace Mist{
     if (readFullPacket){currentPositions.insert(curPos);}
   }// getnext()
 
-  uint64_t inputOGG::calcGranuleTime(size_t tid, uint64_t granule){
+  uint64_t InputOGG::calcGranuleTime(size_t tid, uint64_t granule){
     size_t idx = M.trackIDToIndex(tid, getpid());
     switch (oggTracks[idx].codec){
     case OGG::VORBIS:
@@ -395,7 +395,7 @@ namespace Mist{
   }
 #endif
 
-  void inputOGG::seek(uint64_t seekTime, size_t idx){
+  void InputOGG::seek(uint64_t seekTime, size_t idx){
     currentPositions.clear();
     MEDIUM_MSG("Seeking to %" PRIu64 "ms", seekTime);
 

--- a/src/input/input_ogg.h
+++ b/src/input/input_ogg.h
@@ -35,9 +35,9 @@ namespace Mist{
     uint64_t segmentNo;
   };
 
-  class inputOGG : public Input{
+  class InputOGG : public Input{
   public:
-    inputOGG(Util::Config *cfg);
+    InputOGG(Util::Config *cfg);
 
   protected:
     // Private Functions
@@ -58,4 +58,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputOGG mistIn;
+typedef Mist::InputOGG mistIn;

--- a/src/input/input_playlist.cpp
+++ b/src/input/input_playlist.cpp
@@ -8,7 +8,7 @@
 #include <sys/types.h>
 
 namespace Mist{
-  inputPlaylist::inputPlaylist(Util::Config *cfg) : Input(cfg){
+  InputPlaylist::InputPlaylist(Util::Config *cfg) : Input(cfg){
     capa["name"] = "Playlist";
     capa["desc"] = "Enables Playlist Input";
     capa["source_match"].append("/*.pls");
@@ -20,7 +20,7 @@ namespace Mist{
     playlistIndex = 0xFFFFFFFEull; // Not FFFFFFFF on purpose!
   }
 
-  bool inputPlaylist::checkArguments(){
+  bool InputPlaylist::checkArguments(){
     if (config->getString("input") == "-"){
       Util::logExitReason(ER_FORMAT_SPECIFIC, "Input from stdin not yet supported");
       return false;
@@ -39,7 +39,7 @@ namespace Mist{
     return true;
   }
 
-  void inputPlaylist::streamMainLoop(){
+  void InputPlaylist::streamMainLoop(){
     bool seenValidEntry = true;
     Comms::Users killSwitch;
     killSwitch.reload(streamName, (size_t)INVALID_TRACK_ID, (uint8_t)(COMM_STATUS_ACTIVE | COMM_STATUS_DONOTTRACK));
@@ -134,7 +134,7 @@ namespace Mist{
     }
   }
 
-  void inputPlaylist::reloadPlaylist(){
+  void InputPlaylist::reloadPlaylist(){
     minIndex = std::string::npos;
     maxIndex = std::string::npos;
     std::string playlistFile;

--- a/src/input/input_playlist.h
+++ b/src/input/input_playlist.h
@@ -3,9 +3,9 @@
 #include <mist/dtsc.h>
 
 namespace Mist{
-  class inputPlaylist : public Input{
+  class InputPlaylist : public Input{
   public:
-    inputPlaylist(Util::Config *cfg);
+    InputPlaylist(Util::Config *cfg);
     bool needsLock(){return false;}
 
   protected:
@@ -28,4 +28,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputPlaylist mistIn;
+typedef Mist::InputPlaylist mistIn;

--- a/src/input/input_subrip.cpp
+++ b/src/input/input_subrip.cpp
@@ -1,8 +1,8 @@
-#include "input_srt.h"
+#include "input_subrip.h"
 
 namespace Mist{
 
-  InputSrt::InputSrt(Util::Config *cfg) : Input(cfg){
+  InputSubRip::InputSubRip(Util::Config *cfg) : Input(cfg){
     vtt = false;
     capa["name"] = "SubRip";
     capa["decs"] =
@@ -13,7 +13,7 @@ namespace Mist{
     capa["codecs"]["subtitle"].append("subtitle");
   }
 
-  bool InputSrt::preRun(){
+  bool InputSubRip::preRun(){
     fileSource.close();
     fileSource.open(config->getString("input").c_str());
     if (!fileSource.is_open()){
@@ -23,7 +23,7 @@ namespace Mist{
     return true;
   }
 
-  bool InputSrt::checkArguments(){
+  bool InputSubRip::checkArguments(){
     if (config->getString("input") == "-"){
       Util::logExitReason(ER_FORMAT_SPECIFIC, "Input from stdin not yet supported");
       return false;
@@ -45,7 +45,7 @@ namespace Mist{
     return true;
   }
 
-  bool InputSrt::readHeader(){
+  bool InputSubRip::readHeader(){
     if (!fileSource.good()){
       Util::logExitReason(ER_READ_START_FAILURE, "Reading header for '%s' failed: Could not open input stream", config->getString("input").c_str());
       return false;
@@ -63,7 +63,7 @@ namespace Mist{
     return true;
   }
 
-  void InputSrt::getNext(size_t idx){
+  void InputSubRip::getNext(size_t idx){
     thisPacket.null();
     std::string line;
 
@@ -131,6 +131,6 @@ namespace Mist{
     thisPacket.null();
   }
 
-  void InputSrt::seek(uint64_t seekTime, size_t idx){fileSource.seekg(0, fileSource.beg);}
+  void InputSubRip::seek(uint64_t seekTime, size_t idx){fileSource.seekg(0, fileSource.beg);}
 
 }// namespace Mist

--- a/src/input/input_subrip.h
+++ b/src/input/input_subrip.h
@@ -6,9 +6,9 @@
 
 namespace Mist{
 
-  class InputSrt : public Input{
+  class InputSubRip : public Input{
   public:
-    InputSrt(Util::Config *cfg);
+    InputSubRip(Util::Config *cfg);
 
   protected:
     std::ifstream fileSource;
@@ -25,4 +25,4 @@ namespace Mist{
 
 }// namespace Mist
 
-typedef Mist::InputSrt mistIn;
+typedef Mist::InputSubRip mistIn;

--- a/src/input/input_ts.cpp
+++ b/src/input/input_ts.cpp
@@ -35,7 +35,7 @@ int64_t timeStampOffset = 0;
 
 void parseThread(void *mistIn){
   uint64_t lastTimeStamp = 0;
-  Mist::inputTS *input = reinterpret_cast<Mist::inputTS *>(mistIn);
+  Mist::InputTS *input = reinterpret_cast<Mist::InputTS *>(mistIn);
 
   size_t tid = 0;
   {
@@ -160,7 +160,7 @@ namespace Mist{
 
   /// Constructor of TS Input
   /// \arg cfg Util::Config that contains all current configurations.
-  inputTS::inputTS(Util::Config *cfg) : Input(cfg){
+  InputTS::InputTS(Util::Config *cfg) : Input(cfg){
     rawMode = false;
     udpMode = false;
     rawIdx = INVALID_TRACK_ID;
@@ -279,7 +279,7 @@ namespace Mist{
     config->addOption("raw", option);
   }
 
-  inputTS::~inputTS(){
+  InputTS::~InputTS(){
     if (!standAlone){
       tthread::lock_guard<tthread::mutex> guard(threadClaimMutex);
       threadTimer.clear();
@@ -289,7 +289,7 @@ namespace Mist{
 
   bool skipPipes = false;
 
-  bool inputTS::checkArguments(){
+  bool InputTS::checkArguments(){
     if (config->getString("input").substr(0, 6) == "srt://"){
       std::string source = config->getString("input");
       HTTP::URL srtUrl(source);
@@ -313,7 +313,7 @@ namespace Mist{
   }
 
   /// Live Setup of TS Input
-  bool inputTS::preRun(){
+  bool InputTS::preRun(){
     std::string const inCfg = config->getString("input");
     udpMode = false;
     rawMode = config->getBool("raw");
@@ -396,7 +396,7 @@ namespace Mist{
     return true;
   }
 
-  void inputTS::dataCallback(const char *ptr, size_t size){
+  void InputTS::dataCallback(const char *ptr, size_t size){
     if (standAlone){
       unitStartSeen |= assembler.assemble(tsStream, ptr, size, true, readPos);
     }else{
@@ -404,11 +404,11 @@ namespace Mist{
     }
     readPos += size;
   }
-  size_t inputTS::getDataCallbackPos() const{
+  size_t InputTS::getDataCallbackPos() const{
     return readPos;
   }
 
-  bool inputTS::needHeader(){
+  bool InputTS::needHeader(){
     if (!standAlone){return false;}
     return Input::needHeader();
   }
@@ -418,7 +418,7 @@ namespace Mist{
   /// It encounters a new PES start, it writes the currently found PES data
   /// for a specific track to metadata. After the entire stream has been read,
   /// it writes the remaining metadata.
-  bool inputTS::readHeader(){
+  bool InputTS::readHeader(){
     if (!reader){
       Util::logExitReason(ER_READ_START_FAILURE, "Reading header for '%s' failed: Could not open input stream", config->getString("input").c_str());
       return false;
@@ -476,7 +476,7 @@ namespace Mist{
   /// At the moment, the logic of sending the last packet that was finished has been implemented,
   /// but the seeking and finding data is not yet ready.
   ///\todo Finish the implementation
-  void inputTS::getNext(size_t idx){
+  void InputTS::getNext(size_t idx){
     size_t pid = (idx == INVALID_TRACK_ID ? 0 : M.getID(idx));
     INSANE_MSG("Getting next on track %zu", idx);
     thisPacket.null();
@@ -516,7 +516,7 @@ namespace Mist{
   }
 
   /// Guarantees the PMT is read and we know about all tracks.
-  void inputTS::postHeader(){
+  void InputTS::postHeader(){
     if (!standAlone){return;}
     tsStream.clear();
     assembler.clear();
@@ -531,7 +531,7 @@ namespace Mist{
   }
 
   /// Seeks to a specific time
-  void inputTS::seek(uint64_t seekTime, size_t idx){
+  void InputTS::seek(uint64_t seekTime, size_t idx){
     uint64_t seekPos = 0xFFFFFFFFull;
     if (idx != INVALID_TRACK_ID){
       uint32_t keyNum = M.getKeyNumForTime(idx, seekTime);
@@ -553,7 +553,7 @@ namespace Mist{
     readPos = reader.getPos();
   }
 
-  bool inputTS::openStreamSource(){
+  bool InputTS::openStreamSource(){
     //Non-UDP mode inputs were already opened in preRun()
     if (!udpMode){return reader;}
     HTTP::URL input_url(config->getString("input"));
@@ -564,7 +564,7 @@ namespace Mist{
     return (udpCon.getSock() != -1);
   }
 
-  void inputTS::streamMainLoop(){
+  void InputTS::streamMainLoop(){
     Comms::Connections statComm;
     uint64_t startTime = Util::bootSecs();
     uint64_t noDataSince = Util::bootSecs();
@@ -730,7 +730,7 @@ namespace Mist{
     }
   }
 
-  void inputTS::finish(){
+  void InputTS::finish(){
     if (standAlone){
       Input::finish();
       return;

--- a/src/input/input_ts.h
+++ b/src/input/input_ts.h
@@ -9,10 +9,10 @@
 
 namespace Mist{
   /// This class contains all functions needed to implement TS Input
-  class inputTS : public Input, public Util::DataCallback{
+  class InputTS : public Input, public Util::DataCallback{
   public:
-    inputTS(Util::Config *cfg);
-    ~inputTS();
+    InputTS(Util::Config *cfg);
+    ~InputTS();
 
     // This function can simply check standAlone because we ensure it's set in checkArguments,
     // which is always called before the first call to needsLock
@@ -56,4 +56,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputTS mistIn;
+typedef Mist::InputTS mistIn;

--- a/src/input/input_tsrist.cpp
+++ b/src/input/input_tsrist.cpp
@@ -21,7 +21,7 @@
 #include <mist/tinythread.h>
 #include <sys/stat.h>
 
-Mist::inputTSRIST *connPtr = 0;
+Mist::InputTSRIST *connPtr = 0;
 Util::Config *cnfPtr = 0;
 
 
@@ -65,7 +65,7 @@ static int cb_recv(void *arg, struct rist_data_block *b){
 namespace Mist{
   /// Constructor of TS Input
   /// \arg cfg Util::Config that contains all current configurations.
-  inputTSRIST::inputTSRIST(Util::Config *cfg) : Input(cfg){
+  InputTSRIST::InputTSRIST(Util::Config *cfg) : Input(cfg){
     rawMode = false;
     rawIdx = INVALID_TRACK_ID;
     lastRawPacket = 0;
@@ -170,12 +170,12 @@ namespace Mist{
     receiver_ctx = 0;
   }
 
-  inputTSRIST::~inputTSRIST(){
+  InputTSRIST::~InputTSRIST(){
     cnfPtr = 0;
     rist_destroy(receiver_ctx);
   }
 
-  bool inputTSRIST::checkArguments(){
+  bool InputTSRIST::checkArguments(){
     if (config->getString("datatrack") == "json"){
       tsStream.setRawDataParser(TS::JSON);
     }
@@ -183,7 +183,7 @@ namespace Mist{
   }
 
   /// Live Setup of SRT Input. Runs only if we are the "main" thread
-  bool inputTSRIST::preRun(){
+  bool InputTSRIST::preRun(){
     rawMode = config->getBool("raw");
     if (rawMode){INFO_MSG("Entering raw mode");}
 
@@ -200,7 +200,7 @@ namespace Mist{
   }
 
   // Retrieve the next packet to be played from the srt connection.
-  void inputTSRIST::getNext(size_t idx){
+  void InputTSRIST::getNext(size_t idx){
     thisPacket.null();
     if (rawMode){
       //Set to false so the other thread knows its safe to fill
@@ -246,12 +246,12 @@ namespace Mist{
     thisPacket.setTime(adjustTime);
   }
 
-  void inputTSRIST::onFail(const std::string & msg){
+  void InputTSRIST::onFail(const std::string & msg){
     FAIL_MSG("%s", msg.c_str());
     Util::logExitReason(ER_FORMAT_SPECIFIC, msg.c_str());
   }
 
-  bool inputTSRIST::openStreamSource(){
+  bool InputTSRIST::openStreamSource(){
     if (rist_receiver_create(&receiver_ctx, (rist_profile)config->getInteger("profile"), &log_settings) != 0){
       onFail("Failed to create RIST receiver context");
       return false;
@@ -282,7 +282,7 @@ namespace Mist{
     return true;
   }
 
-  void inputTSRIST::addData(const char * ptr, size_t len){
+  void InputTSRIST::addData(const char * ptr, size_t len){
     for (size_t o = 0; o+188 <= len; o += 188){
       if (rawMode){
         rawBuffer.append(ptr+o, 188);
@@ -308,7 +308,7 @@ namespace Mist{
   }
 
 
-  void inputTSRIST::connStats(Comms::Connections &statComm){
+  void InputTSRIST::connStats(Comms::Connections &statComm){
     statComm.setUp(0);
     statComm.setDown(downBytes);
     statComm.setHost(getConnectedBinHost());

--- a/src/input/input_tsrist.h
+++ b/src/input/input_tsrist.h
@@ -5,10 +5,10 @@
 
 namespace Mist{
 
-  class inputTSRIST : public Input{
+  class InputTSRIST : public Input{
   public:
-    inputTSRIST(Util::Config *cfg);
-    ~inputTSRIST();
+    InputTSRIST(Util::Config *cfg);
+    ~InputTSRIST();
     virtual bool needsLock(){return false;}
     virtual bool publishesTracks(){return false;}
     virtual std::string getConnectedBinHost(){
@@ -42,4 +42,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputTSRIST mistIn;
+typedef Mist::InputTSRIST mistIn;

--- a/src/input/input_tssrt.cpp
+++ b/src/input/input_tssrt.cpp
@@ -40,7 +40,7 @@ void signal_handler(int signum, siginfo_t *sigInfo, void *ignore){
 // We use threads here for multiple input pushes, because of the internals of the SRT Library
 static void callThreadCallbackSRT(void *socknum){
   // use the accepted socket as the second parameter
-  Mist::inputTSSRT inp(cfgPointer, *(Socket::SRTConnection *)socknum);
+  Mist::InputTSSRT inp(cfgPointer, *(Socket::SRTConnection *)socknum);
   inp.setSingular(false);
   inp.run();
 }
@@ -48,7 +48,7 @@ static void callThreadCallbackSRT(void *socknum){
 namespace Mist{
   /// Constructor of TS Input
   /// \arg cfg Util::Config that contains all current configurations.
-  inputTSSRT::inputTSSRT(Util::Config *cfg, Socket::SRTConnection s) : Input(cfg){
+  InputTSSRT::InputTSSRT(Util::Config *cfg, Socket::SRTConnection s) : Input(cfg){
     rawIdx = INVALID_TRACK_ID;
     lastRawPacket = 0;
     bootMSOffsetCalculated = false;
@@ -158,9 +158,9 @@ namespace Mist{
     singularFlag = true;
   }
 
-  inputTSSRT::~inputTSSRT(){}
+  InputTSSRT::~InputTSSRT(){}
 
-  bool inputTSSRT::checkArguments(){
+  bool InputTSSRT::checkArguments(){
     if (config->getString("datatrack") == "json"){
       tsStream.setRawDataParser(TS::JSON);
     }
@@ -168,7 +168,7 @@ namespace Mist{
   }
 
   /// Live Setup of SRT Input. Runs only if we are the "main" thread
-  bool inputTSSRT::preRun(){
+  bool InputTSSRT::preRun(){
     rawMode = config->getBool("raw");
     if (rawMode){INFO_MSG("Entering raw mode");}
     if (srtConn.getSocket() == -1){
@@ -216,7 +216,7 @@ namespace Mist{
   }
 
   // Retrieve the next packet to be played from the srt connection.
-  void inputTSSRT::getNext(size_t idx){
+  void InputTSSRT::getNext(size_t idx){
     thisPacket.null();
     bool hasPacket = tsStream.hasPacket();
     while (!hasPacket && srtConn && config->is_active){
@@ -284,9 +284,9 @@ namespace Mist{
     thisTime = pktTimeWithOffset;
   }
 
-  bool inputTSSRT::openStreamSource(){return true;}
+  bool InputTSSRT::openStreamSource(){return true;}
 
-  void inputTSSRT::streamMainLoop(){
+  void InputTSSRT::streamMainLoop(){
     // If we do not have a srtConn here, we are the main thread and should start accepting pushes.
     if (srtConn.getSocket() == -1){
       cfgPointer = config;
@@ -308,11 +308,11 @@ namespace Mist{
     srtConn.close();
   }
 
-  bool inputTSSRT::needsLock(){return false;}
+  bool InputTSSRT::needsLock(){return false;}
 
-  void inputTSSRT::setSingular(bool newSingular){singularFlag = newSingular;}
+  void InputTSSRT::setSingular(bool newSingular){singularFlag = newSingular;}
 
-  void inputTSSRT::connStats(Comms::Connections &statComm){
+  void InputTSSRT::connStats(Comms::Connections &statComm){
     statComm.setUp(srtConn.dataUp());
     statComm.setDown(srtConn.dataDown());
     statComm.setPacketCount(srtConn.packetCount());

--- a/src/input/input_tssrt.h
+++ b/src/input/input_tssrt.h
@@ -9,10 +9,10 @@
 
 namespace Mist{
 
-  class inputTSSRT : public Input{
+  class InputTSSRT : public Input{
   public:
-    inputTSSRT(Util::Config *cfg, Socket::SRTConnection s = Socket::SRTConnection());
-    ~inputTSSRT();
+    InputTSSRT(Util::Config *cfg, Socket::SRTConnection s = Socket::SRTConnection());
+    ~InputTSSRT();
     void setSingular(bool newSingular);
     virtual bool needsLock();
     virtual std::string getConnectedBinHost(){
@@ -49,4 +49,4 @@ namespace Mist{
   };
 }// namespace Mist
 
-typedef Mist::inputTSSRT mistIn;
+typedef Mist::InputTSSRT mistIn;

--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -14,7 +14,7 @@ inputs = [
     {'name' : 'Playlist', 'format' : 'playlist'},
     {'name' : 'Balancer', 'format' : 'balancer'},
     {'name' : 'RTSP', 'format' : 'rtsp'},
-    {'name' : 'SubRip', 'format' : 'srt'},
+    {'name' : 'SubRip', 'format' : 'subrip'},
     {'name' : 'SDP', 'format' : 'sdp'},
     {'name' : 'AAC', 'format' : 'aac'},
     {'name' : 'FLAC', 'format' : 'flac'},


### PR DESCRIPTION
Current list looks like:
```
Mist::InputBuffer
Mist::InputEBML
Mist::InputH264
Mist::InputRTSP
Mist::InputSDP
Mist::InputSrt
Mist::inputAAC
Mist::inputAV
Mist::inputBalancer
Mist::inputDTSC
Mist::inputFLAC
Mist::inputFLV
Mist::inputFolder
Mist::inputHLS
Mist::inputISMV
Mist::inputMP3
Mist::inputMP4
Mist::inputOGG
Mist::inputPlaylist
Mist::inputTS
Mist::inputTSRIST
Mist::inputTSSRT
```

This capitalizes the lower-case ones, which makes them consistent with the various `Mist::Output` classes and helps me with the single-binary automation.