### PR TITLE
Add overloads to JSON::Value to allow assignment of size_t types (#214)

### DIFF
--- a/lib/json.cpp
+++ b/lib/json.cpp
@@ -497,6 +497,11 @@ JSON::Value::Value(int64_t val){
   myType = INTEGER;
   intVal = val;
 }
+/// Sets this JSON::Value to the given integer.
+JSON::Value::Value(size_t val){
+  myType = INTEGER;
+  intVal = val;
+}
 
 /// Sets this JSON::Value to the given double.
 JSON::Value::Value(double val){
@@ -689,6 +694,11 @@ JSON::Value &JSON::Value::operator=(const int32_t &rhs){
 
 /// Sets this JSON::Value to the given integer.
 JSON::Value &JSON::Value::operator=(const uint64_t &rhs){
+  return ((*this) = (int64_t)rhs);
+}
+
+/// Sets this JSON::Value to the given integer.
+JSON::Value &JSON::Value::operator=(const size_t &rhs){
   return ((*this) = (int64_t)rhs);
 }
 

--- a/lib/json.h
+++ b/lib/json.h
@@ -46,6 +46,7 @@ namespace JSON{
     Value(int64_t val);
     Value(uint32_t val);
     Value(uint64_t val);
+    Value(size_t val);
     Value(double val);
     Value(bool val);
     // comparison operators
@@ -63,6 +64,7 @@ namespace JSON{
     Value &operator=(const int32_t &rhs);
     Value &operator=(const uint64_t &rhs);
     Value &operator=(const uint32_t &rhs);
+    Value &operator=(const size_t &rhs);
     Value &operator=(const double &rhs);
     Value &operator=(const bool &rhs);
     // converts to basic types


### PR DESCRIPTION
Addresses build-time issue on MacOS. Not tested on other platforms.