### PR TITLE
fixes Unknown version in docker build due to Git tags missing at build time inside Alpine container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 build
-.git
 Dockerfile
 


### PR DESCRIPTION
If `.git` folder is ignored by Docker build it does not get copied into the build container, and the call to `git describe` in https://github.com/DDVTECH/mistserver/blob/master/meson.build#L18 fails, leading to the executables being built with "Unknown" as the version number.

