### PR TITLE
SRT Input Fixes - streamid not sanitized when pushing to wildcard stream; config options ignored

### DIFF
--- a/src/input/input_tssrt.cpp
+++ b/src/input/input_tssrt.cpp
@@ -142,7 +142,10 @@ namespace Mist{
       std::string streamid = srtConn->getStreamName();
       int64_t acc = config->getInteger("acceptable");
       if (acc == 0){
-        if (streamid.size()){streamName += "+" + streamid;}
+        if (streamid.size()){
+          Util::sanitizeName(streamid);
+          streamName += "+" + streamid;
+        }
       }else if(acc == 2){
         if (streamName != streamid){
           FAIL_MSG("Stream ID '%s' does not match stream name, push blocked", streamid.c_str());

--- a/src/input/input_tssrt.cpp
+++ b/src/input/input_tssrt.cpp
@@ -69,74 +69,74 @@ namespace Mist{
     capa["codecs"]["audio"].append("MP2");
     capa["codecs"]["audio"].append("opus");
     capa["codecs"]["passthrough"].append("rawts");
+    // Add configuration options, only if this is the main thread constructor, and not another instance in a thread
+    if (!s.connected() ) {
+      JSON::Value option;
+      option["arg"] = "integer";
+      option["long"] = "buffer";
+      option["short"] = "b";
+      option["help"] = "DVR buffer time in ms";
+      option["value"].append(50000);
+      config->addOption("bufferTime", option);
+      option.null();
+      capa["optional"]["DVR"]["name"] = "Buffer time (ms)";
+      capa["optional"]["DVR"]["help"] =
+          "The target available buffer time for this live stream, in milliseconds. This is the time "
+          "available to seek around in, and will automatically be extended to fit whole keyframes as "
+          "well as the minimum duration needed for stable playback.";
+      capa["optional"]["DVR"]["option"] = "--buffer";
+      capa["optional"]["DVR"]["type"] = "uint";
+      capa["optional"]["DVR"]["default"] = 50000;
 
-    JSON::Value option;
-    option["arg"] = "integer";
-    option["long"] = "buffer";
-    option["short"] = "b";
-    option["help"] = "DVR buffer time in ms";
-    option["value"].append(50000);
-    config->addOption("bufferTime", option);
-    option.null();
-    capa["optional"]["DVR"]["name"] = "Buffer time (ms)";
-    capa["optional"]["DVR"]["help"] =
-        "The target available buffer time for this live stream, in milliseconds. This is the time "
-        "available to seek around in, and will automatically be extended to fit whole keyframes as "
-        "well as the minimum duration needed for stable playback.";
-    capa["optional"]["DVR"]["option"] = "--buffer";
-    capa["optional"]["DVR"]["type"] = "uint";
-    capa["optional"]["DVR"]["default"] = 50000;
+      option["arg"] = "integer";
+      option["long"] = "acceptable";
+      option["short"] = "T";
+      option["help"] = "Acceptable pushed streamids (0 = use streamid as wildcard, 1 = ignore all streamids, 2 = disallow non-matching streamids)";
+      option["value"].append(0);
+      config->addOption("acceptable", option);
+      capa["optional"]["acceptable"]["name"] = "Acceptable pushed streamids";
+      capa["optional"]["acceptable"]["help"] = "What to do with the streamids for incoming pushes, if this is a listener SRT connection";
+      capa["optional"]["acceptable"]["option"] = "--acceptable";
+      capa["optional"]["acceptable"]["short"] = "T";
+      capa["optional"]["acceptable"]["default"] = 0;
+      capa["optional"]["acceptable"]["type"] = "select";
+      capa["optional"]["acceptable"]["select"][0u][0u] = 0;
+      capa["optional"]["acceptable"]["select"][0u][1u] = "Set streamid as wildcard";
+      capa["optional"]["acceptable"]["select"][1u][0u] = 1;
+      capa["optional"]["acceptable"]["select"][1u][1u] = "Ignore all streamids";
+      capa["optional"]["acceptable"]["select"][2u][0u] = 2;
+      capa["optional"]["acceptable"]["select"][2u][1u] = "Disallow non-matching streamid";
+      capa["optional"]["raw"]["name"] = "Raw input mode";
+      capa["optional"]["raw"]["help"] = "Enable raw MPEG-TS passthrough mode";
+      capa["optional"]["raw"]["option"] = "--raw";
 
-    option["arg"] = "integer";
-    option["long"] = "acceptable";
-    option["short"] = "T";
-    option["help"] = "Acceptable pushed streamids (0 = use streamid as wildcard, 1 = ignore all streamids, 2 = disallow non-matching streamids)";
-    option["value"].append(0);
-    config->addOption("acceptable", option);
-    capa["optional"]["acceptable"]["name"] = "Acceptable pushed streamids";
-    capa["optional"]["acceptable"]["help"] = "What to do with the streamids for incoming pushes, if this is a listener SRT connection";
-    capa["optional"]["acceptable"]["option"] = "--acceptable";
-    capa["optional"]["acceptable"]["short"] = "T";
-    capa["optional"]["acceptable"]["default"] = 0;
-    capa["optional"]["acceptable"]["type"] = "select";
-    capa["optional"]["acceptable"]["select"][0u][0u] = 0;
-    capa["optional"]["acceptable"]["select"][0u][1u] = "Set streamid as wildcard";
-    capa["optional"]["acceptable"]["select"][1u][0u] = 1;
-    capa["optional"]["acceptable"]["select"][1u][1u] = "Ignore all streamids";
-    capa["optional"]["acceptable"]["select"][2u][0u] = 2;
-    capa["optional"]["acceptable"]["select"][2u][1u] = "Disallow non-matching streamid";
+      option.null();
+      option["long"] = "raw";
+      option["short"] = "R";
+      option["help"] = "Enable raw MPEG-TS passthrough mode";
+      config->addOption("raw", option);
+      
+      capa["optional"]["datatrack"]["name"] = "MPEG Data track parser";
+      capa["optional"]["datatrack"]["help"] = "Which parser to use for data tracks";
+      capa["optional"]["datatrack"]["type"] = "select";
+      capa["optional"]["datatrack"]["option"] = "--datatrack";
+      capa["optional"]["datatrack"]["short"] = "D";
+      capa["optional"]["datatrack"]["default"] = "";
+      capa["optional"]["datatrack"]["select"][0u][0u] = "";
+      capa["optional"]["datatrack"]["select"][0u][1u] = "None / disabled";
+      capa["optional"]["datatrack"]["select"][1u][0u] = "json";
+      capa["optional"]["datatrack"]["select"][1u][1u] = "2b size-prepended JSON";
 
-    capa["optional"]["raw"]["name"] = "Raw input mode";
-    capa["optional"]["raw"]["help"] = "Enable raw MPEG-TS passthrough mode";
-    capa["optional"]["raw"]["option"] = "--raw";
-
-    option.null();
-    option["long"] = "raw";
-    option["short"] = "R";
-    option["help"] = "Enable raw MPEG-TS passthrough mode";
-    config->addOption("raw", option);
-    
-    capa["optional"]["datatrack"]["name"] = "MPEG Data track parser";
-    capa["optional"]["datatrack"]["help"] = "Which parser to use for data tracks";
-    capa["optional"]["datatrack"]["type"] = "select";
-    capa["optional"]["datatrack"]["option"] = "--datatrack";
-    capa["optional"]["datatrack"]["short"] = "D";
-    capa["optional"]["datatrack"]["default"] = "";
-    capa["optional"]["datatrack"]["select"][0u][0u] = "";
-    capa["optional"]["datatrack"]["select"][0u][1u] = "None / disabled";
-    capa["optional"]["datatrack"]["select"][1u][0u] = "json";
-    capa["optional"]["datatrack"]["select"][1u][1u] = "2b size-prepended JSON";
-
-    option.null();
-    option["long"] = "datatrack";
-    option["short"] = "D";
-    option["arg"] = "string";
-    option["default"] = "";
-    option["help"] = "Which parser to use for data tracks";
-    config->addOption("datatrack", option);
-
-    // Setup if we are called form with a thread for push-based input.
-    if (s.connected()){
+      option.null();
+      option["long"] = "datatrack";
+      option["short"] = "D";
+      option["arg"] = "string";
+      option["default"] = "";
+      option["help"] = "Which parser to use for data tracks";
+      config->addOption("datatrack", option);
+    }
+    else {
+      // Setup if we are called form with a thread for push-based input.
       srtConn = new Socket::SRTConnection(s);
       streamName = baseStreamName;
       std::string streamid = srtConn->getStreamName();

--- a/src/input/input_tssrt.cpp
+++ b/src/input/input_tssrt.cpp
@@ -140,6 +140,9 @@ namespace Mist{
       srtConn = new Socket::SRTConnection(s);
       streamName = baseStreamName;
       std::string streamid = srtConn->getStreamName();
+      if (streamid.size()){
+        INFO_MSG("Received SRT streamid '%s'",streamid.c_str());
+      }
       int64_t acc = config->getInteger("acceptable");
       if (acc == 0){
         if (streamid.size()){


### PR DESCRIPTION
1. When pushing to an SRT input (srt://:[PORT]), the incoming streamid was not sanitized the way it is done in https://github.com/DDVTECH/mistserver/blob/d1cb436c81f2fc03b234cefe1d98988e40976ab7/src/output/output_tssrt.cpp#L122 . Some encoders (Blackmagic Design WebPresenter) send a fixed streamid that has special characters - BMD's look like '#!::bmd_uuid=460b34e1-0d3d-4758-ba7e-f9409f79be20,bmd_name=devicename'. When new streams created with these names unsanitized, a lot of things break. Fix is 72689a8

2. Currently all configuration options for SRT inputs are ignored and defaults are used. The easiest way to test this is to set the "Acceptable pushed streamids:" option to "Ignore..." (1) and push an srt stream with a stream id. The expected behavior is to discard stream ID and not treat the stream name as wildcard. In the release, the server behaves as if this option is set to 0 (default) - "Set Streamid as wildcard", regardless of what actual setting is used. 

This happens because when config->addOption() is invoked the second time after the config has already been initialized in a constructor called in a thread, it erases the option values passed via the command line and resets them to default. f20826c is the fix.

3. Added logging of incoming streamid at INFO level before it is sanitized - good for troubleshooting (aafa359)

