### PR TITLE
suppress warning for 'protocols' field from externalWritersToShm()

### DIFF
--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -1100,8 +1100,8 @@ namespace Util{
     // calculate fLen if missing
     if (!fLen){
       fLen = getDefaultSize(fType);
-      if (!fLen){
-        WARN_MSG("Attempting to add a mandatory-size field without size");
+      if (!fLen && fType != RAX_NESTED) {
+        WARN_MSG("Attempting to add a mandatory-size field '%s' without size", name.c_str());
         return;
       }
     }


### PR DESCRIPTION
suppresses a confusing warning "Attempting to add a mandatory-size field without size" that is caused by externalWritersToShm() processing an empty external writers list.

Assumption is made that 0 is a valid size for RAX_NESTED field than may be an empty object.

Added logging the field name in case this warning does show up for legitimate reasons.