### PR TITLE
Don't call SSL-only function with NOSSL

### DIFF
--- a/lib/ev.cpp
+++ b/lib/ev.cpp
@@ -121,7 +121,9 @@ namespace Event{
     uint64_t currPace = Util::getMicros();
     for (auto it : sendQueues){
       if (it->finTimer) {
+#ifdef SSL
         if (it->finTimer <= startTime) { it->handshake(); }
+#endif
         if (it->finTimer && it->finTimer > startTime && it->finTimer - startTime < maxMs) {
           maxMs = it->finTimer - startTime;
         }


### PR DESCRIPTION
I noticed a build failure with the `-DNOSSL=true` option. This fixes the build issue, but I haven't investigated other side effects.